### PR TITLE
Add support for Temperature and Humidity sensor 

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,8 @@ lib_deps_external =
 	h2zero/NimBLE-Arduino@^1.3.1
 	me-no-dev/AsyncTCP@^1.1.1
 	bbx10/DNSServer@^1.1.0
+	adafruit/Adafruit Unified Sensor @ ^1.1.4
+	beegee-tokyo/DHT sensor library for ESPx @ ^1.18
 
 [env:esp32]
 platform = espressif32

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,6 +147,10 @@ void connectToWifi()
     Serial.println(pirPin ? "enabled" : "disabled");
     Serial.print("Radar Sensor: ");
     Serial.println(radarPin ? "enabled" : "disabled");
+    Serial.print("DHT11 Sensor: ");
+    Serial.println(dht11Pin ? "enabled" : "disabled");
+    Serial.print("DHT22 Sensor: ");
+    Serial.println(dht22Pin ? "enabled" : "disabled");
 
     localIp = WiFi.localIP().toString();
     roomsTopic = CHANNEL + "/rooms/" + room;
@@ -286,6 +290,41 @@ void scanForDevices(void *parameter)
     }
 }
 
+/**
+ * Task to reads temperature from DHT11 sensor
+ * @param pvParameters
+ *		pointer to task parameters
+ */
+void tempTask(void *pvParameters) 
+{
+	Serial.println("tempTask loop started");
+	while (1) // tempTask loop
+	{
+		if (dhtTasksEnabled && !gotNewTemperature) 
+        { 
+            // Read temperature only if old data was processed already
+			// Reading temperature for humidity takes about 250 milliseconds!
+			// Sensor readings may also be up to 2 seconds 'old' (it's a very slow sensor)
+			dhtSensorData = dhtSensor.getTempAndHumidity();	// Read values from sensor 1
+			gotNewTemperature = true;
+		}
+		vTaskSuspend(NULL);
+	}
+}
+
+/**
+ * triggerGetTemp
+ * Sets flag dhtUpdated to true for handling in loop()
+ * called by Ticker tempTicker
+ */
+void triggerGetTemp() 
+{
+	if (dhtTempTaskHandle != NULL) 
+    {
+		 xTaskResumeFromISR(dhtTempTaskHandle);
+	}
+}
+
 void setup()
 {
 #ifdef LED_BUILTIN
@@ -301,8 +340,34 @@ void setup()
     connectToWifi();
     if (pirPin) pinMode(pirPin, INPUT);
     if (radarPin) pinMode(radarPin, INPUT);
-    if (dht11Pin) dht.setup(dht11Pin, DHTesp::DHT11);
-    if (dht22Pin) dht.setup(dht11Pin, DHTesp::DHT22); //(AM2302)
+    if (dht11Pin) dhtSensor.setup(dht11Pin, DHTesp::DHT11);
+    if (dht22Pin) dhtSensor.setup(dht22Pin, DHTesp::DHT22); //(AM2302)
+
+    if (dht11Pin || dht22Pin) 
+    {
+        // Start task to get temperature
+        xTaskCreatePinnedToCore(
+                tempTask,			    /* Function to implement the task */
+                "tempTask ",		    /* Name of the task */
+                4000,				    /* Stack size in words */
+                NULL,			    	/* Task input parameter */
+                5,			    		/* Priority of the task */
+                &dhtTempTaskHandle,		/* Task handle. */
+                1);						/* Core where the task should run */
+
+        if (dhtTempTaskHandle == NULL) 
+        {
+            Serial.println("[ERROR] Failed to start task for temperature update");
+        } else 
+        {
+            // Start update of environment data every 10 seconds
+            tempTicker.attach(dhtUpdateTime, triggerGetTemp);
+        }
+
+        // Signal end of setup() to tasks
+        dhtTasksEnabled = true;
+    }
+
 
 #if NTP
     setClock();
@@ -360,30 +425,31 @@ void radarLoop()
 void dhtLoop()
 {
     if (!dht11Pin && !dht22Pin) return ;
-    delay(dht.getMinimumSamplingPeriod());
 
-    float humidity = dht.getHumidity();
-    float temperature = dht.getTemperature();
+    if (gotNewTemperature) 
+    {
+        float humidity = dhtSensorData.humidity;
+        float temperature = dhtSensorData.temperature;
+        Serial.println("Temp: " + String(temperature,2) + "'C Humidity: " + String(humidity,1) + "%");
+ 
+        mqttClient.publish((roomsTopic + "/humidity").c_str(), 0, 1, String(humidity).c_str());
+        mqttClient.publish((roomsTopic + "/temperature").c_str(), 0, 1, String(temperature).c_str());
 
-    Serial.print(dht.getStatusString());
-    Serial.print("\t");
-    Serial.print(humidity, 1);
-    Serial.print("\t\t");
-    Serial.print(temperature, 1);
-    Serial.print("\t\t");
-    Serial.println(dht.computeHeatIndex(temperature, humidity, false), 1);    
+        gotNewTemperature = false;
+    }    
 
-    mqttClient.publish((roomsTopic + "/humidity").c_str(), 0, 1, String(humidity).c_str());
-    mqttClient.publish((roomsTopic + "/temperature").c_str(), 0, 1, String(temperature).c_str());
 }
 
+
+
+
 void loop()
-{
-    dhtLoop();
+{    
     ArduinoOTA.handle();
     firmwareUpdate();
     Display.update();
     pirLoop();
     radarLoop();
+    dhtLoop();
     WiFiSettings.httpLoop();
 }

--- a/src/main.h
+++ b/src/main.h
@@ -19,6 +19,8 @@
 #include "BleFingerprintCollection.h"
 #include "GUI.h"
 #include "Settings.h"
+#include <Adafruit_Sensor.h>
+#include "DHTesp.h"
 
 AsyncMqttClient mqttClient;
 TimerHandle_t reconnectTimer;
@@ -48,10 +50,13 @@ bool discovery;
 int maxDistance;
 int pirPin;
 int radarPin;
+int dht11Pin;
+int dht22Pin;
 
 int lastPirValue = -1;
 int lastRadarValue = -1;
 
+DHTesp dht;
 BleFingerprintCollection fingerprints(MAX_MAC_ADDRESSES);
 
 String resetReason(RESET_REASON reason)
@@ -313,6 +318,65 @@ bool sendDiscoveryMotion()
     doc["availability_topic"] = "~/status";
     doc["stat_t"] = "~/motion";
     doc["dev_cla"] = "motion";
+
+    commonDiscovery(&doc);
+    serializeJson(doc, buffer);
+
+    for (int i = 0; i < 10; i++)
+    {
+        if (mqttClient.publish(discoveryTopic.c_str(), 0, true, buffer))
+            return true;
+        delay(50);
+    }
+    return false;
+}
+
+bool sendDiscoveryTemperature()
+{
+    if (!discovery) return true;
+    if (!dht11Pin && !dht22Pin) return true;
+
+    String discoveryTopic = "homeassistant/sensor/espresense_" + room + "/temperature/config";
+
+    DynamicJsonDocument doc(1200);
+    char buffer[1200];
+
+    doc["~"] = roomsTopic;
+    doc["name"] = "ESPresense " + room + " Temperature";
+    doc["unique_id"] = WiFi.macAddress() + "_temperature";
+    doc["availability_topic"] = "~/status";
+    doc["stat_t"] = "~/temperature";
+    doc["dev_cla"] = "temperature";
+    doc["unit_of_measurement"] = "C°";
+
+    commonDiscovery(&doc);
+    serializeJson(doc, buffer);
+
+    for (int i = 0; i < 10; i++)
+    {
+        if (mqttClient.publish(discoveryTopic.c_str(), 0, true, buffer))
+            return true;
+        delay(50);
+    }
+    return false;
+}
+
+bool sendDiscoveryHumidity()
+{
+    if (!discovery) return true;
+    if (!dht11Pin && !dht22Pin) return true;
+
+    String discoveryTopic = "homeassistant/sensor/espresense_" + room + "/humidity/config";
+
+    DynamicJsonDocument doc(1200);
+    char buffer[1200];
+
+    doc["~"] = roomsTopic;
+    doc["name"] = "ESPresense " + room + " Humidity";
+    doc["unique_id"] = WiFi.macAddress() + "_humidity";
+    doc["availability_topic"] = "~/status";
+    doc["stat_t"] = "~/humidity";
+    doc["dev_cla"] = "humidity";
 
     commonDiscovery(&doc);
     serializeJson(doc, buffer);

--- a/src/main.h
+++ b/src/main.h
@@ -19,8 +19,8 @@
 #include "BleFingerprintCollection.h"
 #include "GUI.h"
 #include "Settings.h"
-#include <Adafruit_Sensor.h>
 #include "DHTesp.h"
+#include <Ticker.h>
 
 AsyncMqttClient mqttClient;
 TimerHandle_t reconnectTimer;
@@ -57,7 +57,27 @@ int dht22Pin;
 int lastPirValue = -1;
 int lastRadarValue = -1;
 
-DHTesp dht;
+/** Initialize DHT sensor 1 */
+DHTesp dhtSensor;
+
+/** Task handle for the light value read task */
+TaskHandle_t dhtTempTaskHandle = NULL;
+
+/** Ticker for temperature reading */
+Ticker tempTicker;
+
+/** Flags for temperature readings finished */
+bool gotNewTemperature = false;
+
+/** Data from dht sensor 1 */
+TempAndHumidity dhtSensorData;
+
+/* Flag if main loop is running */
+bool dhtTasksEnabled = false;
+
+/* update time */
+int dhtUpdateTime = 10; //ToDo: maybe make this a user choise via settings menu
+
 BleFingerprintCollection fingerprints(MAX_MAC_ADDRESSES);
 
 String resetReason(RESET_REASON reason)


### PR DESCRIPTION
I have around 20 Temperature & Humidity sensors around the house, which all could be obsolete, if this new BT & Motion detector would measure Temperature & Humidity. 
This also has the advantage of getting the data much faster, as from battery driven devices for example to turn on the fan in the bathroom much quicker if someone is in the shower.  

I added support for the 2 most used sensors, the DHT11 and the DHT22 with Home Assistant Auto Discover.
https://github.com/smrtnt/Open-Home-Automation/tree/master/ha_mqtt_sensor_dht22 

What I could not found out, how Home Assistant handles the temperature values if the System Settings are in Fahrenheit and a sensor reports in Celsius. Are they converted internal, or should I let the user choose between reporting Celsius or Fahrenheit?

Maybe it would make sense to put these extra Sensors and Libraries into an own [env:esp32-extraSensors] section, to not blown up this thing with unused stuff.