### PR TITLE
Add device model to apple fingerprints add support room assistant app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Settings_*.h
 .pio
 .vscode
 .scripts
+.DS_Store

--- a/lib/BleFingerprint/BleFingerprint.cpp
+++ b/lib/BleFingerprint/BleFingerprint.cpp
@@ -62,6 +62,7 @@ void BleFingerprint::fingerprint(BLEAdvertisedDevice *advertisedDevice)
             std::string strServiceData = advertisedDevice->getServiceData(exposureUUID);
             calRssi = _parent->getRefRssi() + EXPOSURE_TX;
             if (!pidOverriden) pid = "exp:" + String(strServiceData.length());
+            name = hexStr(strServiceData).c_str();
         }
         else if (advertisedDevice->isAdvertisingService(sonosUUID))
         {
@@ -120,7 +121,7 @@ void BleFingerprint::fingerprint(BLEAdvertisedDevice *advertisedDevice)
 #ifdef VERBOSE
         Serial.printf("Verbose | %-58sMD: %s\n", getId().c_str(), hexStr(strManufacturerData).c_str());
 #endif
-        if (strManufacturerData.length() > 2)
+        if (strManufacturerData.length() >= 2)
         {
             String manuf = Sprintf("%02x%02x", strManufacturerData[1], strManufacturerData[0]);
 
@@ -169,11 +170,12 @@ void BleFingerprint::fingerprint(BLEAdvertisedDevice *advertisedDevice)
             else if (manuf == "0006" && strManufacturerData.length() == 29) //microsoft
             {
                 mdRssi = advertisedDevice->haveTXPower() ? _parent->getRefRssi() + advertisedDevice->getTXPower() : NO_RSSI;
-                sid = Sprintf("microsoft:%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
-                                                 strManufacturerData[6], strManufacturerData[7], strManufacturerData[8], strManufacturerData[9], strManufacturerData[10], strManufacturerData[11],
-                                                 strManufacturerData[12], strManufacturerData[13], strManufacturerData[14], strManufacturerData[15], strManufacturerData[16], strManufacturerData[17],
-                                                 strManufacturerData[18], strManufacturerData[19], strManufacturerData[20], strManufacturerData[21], strManufacturerData[22], strManufacturerData[23],
-                                                 strManufacturerData[24], strManufacturerData[25], strManufacturerData[26], strManufacturerData[27], strManufacturerData[28]);
+                pid = "md:microsoft:29";
+                name = Sprintf("%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+                               strManufacturerData[6], strManufacturerData[7], strManufacturerData[8], strManufacturerData[9], strManufacturerData[10], strManufacturerData[11],
+                               strManufacturerData[12], strManufacturerData[13], strManufacturerData[14], strManufacturerData[15], strManufacturerData[16], strManufacturerData[17],
+                               strManufacturerData[18], strManufacturerData[19], strManufacturerData[20], strManufacturerData[21], strManufacturerData[22], strManufacturerData[23],
+                               strManufacturerData[24], strManufacturerData[25], strManufacturerData[26], strManufacturerData[27], strManufacturerData[28]);
                 ignore = true;
             }
             else if (manuf == "0075") //samsung

--- a/lib/BleFingerprint/BleFingerprint.cpp
+++ b/lib/BleFingerprint/BleFingerprint.cpp
@@ -316,7 +316,7 @@ bool BleFingerprint::query()
         if (!sRmAst.empty())
         {
             Serial.printf("%d RmAst | MAC: %s, ID: %-50s%s\n", xPortGetCoreID(), getMac().c_str(), getId().c_str(), sRmAst.c_str());
-            pid = String("roomAssistant:") + kebabify(sRmAst).c_str();
+            if (!pidOverriden) pid = String("roomAssistant:") + kebabify(sRmAst).c_str();
             pidOverriden = true;
         }
         else
@@ -325,11 +325,13 @@ bool BleFingerprint::query()
             if (!sMdl.empty())
             {
                 Serial.printf("%d Model | MAC: %s, ID: %-50s%s\n", xPortGetCoreID(), getMac().c_str(), getId().c_str(), sMdl.c_str());
-                qry = String("-") + kebabify(sMdl).c_str();
+                if (!pidOverriden) pid = String("-") + kebabify(sMdl).c_str();
+                pidOverriden = true;
             }
             else
             {
-                if (name.length() > 0) qry = String("-") + kebabify(name);
+                if (name.length() > 0 && !pidOverriden) pid = pid + String("-") + kebabify(name);
+                pidOverriden = true;
             }
         }
 

--- a/lib/BleFingerprint/BleFingerprint.cpp
+++ b/lib/BleFingerprint/BleFingerprint.cpp
@@ -169,7 +169,7 @@ void BleFingerprint::fingerprint(BLEAdvertisedDevice *advertisedDevice)
             else if (manuf == "0006" && strManufacturerData.length() == 29) //microsoft
             {
                 mdRssi = advertisedDevice->haveTXPower() ? _parent->getRefRssi() + advertisedDevice->getTXPower() : NO_RSSI;
-                if (!pidOverriden) sid = Sprintf("microsoft:%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+                sid = Sprintf("microsoft:%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
                                                  strManufacturerData[6], strManufacturerData[7], strManufacturerData[8], strManufacturerData[9], strManufacturerData[10], strManufacturerData[11],
                                                  strManufacturerData[12], strManufacturerData[13], strManufacturerData[14], strManufacturerData[15], strManufacturerData[16], strManufacturerData[17],
                                                  strManufacturerData[18], strManufacturerData[19], strManufacturerData[20], strManufacturerData[21], strManufacturerData[22], strManufacturerData[23],

--- a/lib/BleFingerprint/BleFingerprint.cpp
+++ b/lib/BleFingerprint/BleFingerprint.cpp
@@ -205,6 +205,7 @@ bool BleFingerprint::filter()
 bool BleFingerprint::seen(BLEAdvertisedDevice *advertisedDevice)
 {
     lastSeenMillis = millis();
+    seenCount++;
 
     if (ignore) return false;
 

--- a/lib/BleFingerprint/BleFingerprint.cpp
+++ b/lib/BleFingerprint/BleFingerprint.cpp
@@ -325,7 +325,7 @@ bool BleFingerprint::query()
             if (!sMdl.empty())
             {
                 Serial.printf("%d Model | MAC: %s, ID: %-50s%s\n", xPortGetCoreID(), getMac().c_str(), getId().c_str(), sMdl.c_str());
-                if (!pidOverriden) pid = String("-") + kebabify(sMdl).c_str();
+                if (!pidOverriden) pid = pid + String("-") + kebabify(sMdl).c_str();
                 pidOverriden = true;
             }
             else

--- a/lib/BleFingerprint/BleFingerprint.h
+++ b/lib/BleFingerprint/BleFingerprint.h
@@ -25,11 +25,11 @@ public:
 
     bool seen(BLEAdvertisedDevice *advertisedDevice);
     bool report(JsonDocument *doc, float maxDistance);
-    void connect();
+    bool query();
 
     String getId()
     {
-        if (!pid.isEmpty()) return pid;
+        if (!pid.isEmpty()) return pid + qry;
         if (macPublic) return getMac();
         if (!sid.isEmpty()) return sid;
         return getMac();
@@ -51,17 +51,18 @@ private:
     void fingerprint(BLEAdvertisedDevice *advertisedDevice);
 
     BleFingerprintCollection *_parent;
-    bool hasValue = false, close = false, reported = false, macPublic = false, ignore = false, readAddlChar = false, connectAttempted = false;
+    bool hasValue = false, close = false, reported = false, macPublic = false, ignore = false, shouldQuery = false, didQuery = false, pidOverriden = false;
     NimBLEAddress address;
-    String pid, sid, name, url;
+    String pid, sid, name, url, qry;
     int rssi = -100, calRssi = NO_RSSI, mdRssi = NO_RSSI, asRssi = NO_RSSI;
     int newest = -100;
     int recent = -100;
     int oldest = -100;
+    int qryAttempts = 0;
+
     float raw = 0, lastReported = 0, temp = 0;
-    unsigned long firstSeenMillis, lastSeenMillis = 0, lastReportedMillis = 0;
+    unsigned long firstSeenMillis, lastSeenMillis = 0, lastReportedMillis = 0, lastQryMillis = 0;
     uint16_t volts = 0;
-    BLEUUID service, characteristic;
 
     Reading<Differential<float>> output;
 
@@ -69,19 +70,5 @@ private:
     DifferentialFilter<float, long long> diffFilter;
 
     bool filter();
-
-    void onConnect(NimBLEClient *pClient);
-    void onDisconnect(NimBLEClient *pClient);
-    void onAuthenticationComplete(ble_gap_conn_desc *desc);
-
-    struct constructor
-    {
-        constructor()
-        {
-            connectionsUnderway = 0;
-        }
-    };
-    static int connectionsUnderway;
-    static constructor cons;
 };
 #endif

--- a/lib/BleFingerprint/BleFingerprint.h
+++ b/lib/BleFingerprint/BleFingerprint.h
@@ -9,7 +9,6 @@
 #include <NimBLEEddystoneTLM.h>
 #include <NimBLEEddystoneURL.h>
 #include <SoftFilters.h>
-#include <esp_gattc_api.h>
 
 #define NO_RSSI -32768
 

--- a/lib/BleFingerprint/BleFingerprint.h
+++ b/lib/BleFingerprint/BleFingerprint.h
@@ -46,6 +46,12 @@ public:
     NimBLEAddress getAddress() { return address; }
     long getAge() { return millis() - lastSeenMillis; };
     bool getIgnore() { return ignore; };
+    int getSeenCount()
+    {
+        auto sc = seenCount;
+        seenCount = 0;
+        return sc;
+    }
 
 private:
     void fingerprint(BLEAdvertisedDevice *advertisedDevice);
@@ -55,10 +61,8 @@ private:
     NimBLEAddress address;
     String pid, sid, name, url, qry;
     int rssi = -100, calRssi = NO_RSSI, mdRssi = NO_RSSI, asRssi = NO_RSSI;
-    int newest = -100;
-    int recent = -100;
-    int oldest = -100;
-    int qryAttempts = 0;
+    int newest = -100, recent = -100, oldest = -100;
+    int qryAttempts = 0, seenCount = 1;
 
     float raw = 0, lastReported = 0, temp = 0;
     unsigned long firstSeenMillis, lastSeenMillis = 0, lastReportedMillis = 0, lastQryMillis = 0;

--- a/lib/BleFingerprint/BleFingerprint.h
+++ b/lib/BleFingerprint/BleFingerprint.h
@@ -9,7 +9,6 @@
 #include <NimBLEEddystoneTLM.h>
 #include <NimBLEEddystoneURL.h>
 #include <SoftFilters.h>
-#include <esp_gap_ble_api.h>
 #include <esp_gattc_api.h>
 
 #define NO_RSSI -32768

--- a/lib/BleFingerprint/BleFingerprint.h
+++ b/lib/BleFingerprint/BleFingerprint.h
@@ -9,7 +9,6 @@
 #include <NimBLEEddystoneTLM.h>
 #include <NimBLEEddystoneURL.h>
 #include <SoftFilters.h>
-#include <esp_bt_defs.h>
 #include <esp_gap_ble_api.h>
 #include <esp_gattc_api.h>
 

--- a/lib/BleFingerprint/BleFingerprint.h
+++ b/lib/BleFingerprint/BleFingerprint.h
@@ -14,7 +14,7 @@
 
 class BleFingerprintCollection;
 
-class BleFingerprint : public NimBLEClientCallbacks
+class BleFingerprint
 {
 
 public:

--- a/lib/BleFingerprint/BleFingerprint.h
+++ b/lib/BleFingerprint/BleFingerprint.h
@@ -26,7 +26,7 @@ public:
 
     String getId()
     {
-        if (!pid.isEmpty()) return pid + qry;
+        if (!pid.isEmpty()) return pid;
         if (macPublic) return getMac();
         if (!sid.isEmpty()) return sid;
         return getMac();
@@ -56,7 +56,7 @@ private:
     BleFingerprintCollection *_parent;
     bool hasValue = false, close = false, reported = false, macPublic = false, ignore = false, shouldQuery = false, didQuery = false, pidOverriden = false;
     NimBLEAddress address;
-    String pid, sid, name, url, qry;
+    String pid, sid, name, url;
     int rssi = -100, calRssi = NO_RSSI, mdRssi = NO_RSSI, asRssi = NO_RSSI;
     int newest = -100, recent = -100, oldest = -100;
     int qryAttempts = 0, seenCount = 1;

--- a/lib/BleFingerprint/BleFingerprintCollection.cpp
+++ b/lib/BleFingerprint/BleFingerprintCollection.cpp
@@ -2,6 +2,9 @@
 
 void BleFingerprintCollection::cleanupOldFingerprints()
 {
+    auto now = millis();
+    if (now - lastCleanup < 5000) return;
+    lastCleanup = now;
     auto it = fingerprints.begin();
     while (it != fingerprints.end())
     {

--- a/lib/BleFingerprint/BleFingerprintCollection.cpp
+++ b/lib/BleFingerprint/BleFingerprintCollection.cpp
@@ -52,13 +52,13 @@ BleFingerprint *BleFingerprintCollection::getFingerprint(BLEAdvertisedDevice *ad
     return f;
 }
 
-std::list<BleFingerprint *> BleFingerprintCollection::getSeen()
+std::list<BleFingerprint *> BleFingerprintCollection::getCopy()
 {
     if (xSemaphoreTake(fingerprintSemaphore, 1000) != pdTRUE)
         log_e("Couldn't take semaphore!");
     cleanupOldFingerprints();
-    std::list<BleFingerprint *> seen(fingerprints);
+    std::list<BleFingerprint *> copy(fingerprints);
     if (xSemaphoreGive(fingerprintSemaphore) != pdTRUE)
         log_e("Couldn't give semaphore!");
-    return seen;
+    return copy;
 }

--- a/lib/BleFingerprint/BleFingerprintCollection.h
+++ b/lib/BleFingerprint/BleFingerprintCollection.h
@@ -37,6 +37,7 @@ private:
 
     float _maxDistance, _skipDistance;
     int _refRssi, _forgetMs, _skipMs;
+    unsigned long lastCleanup = 0;
 
     SemaphoreHandle_t fingerprintSemaphore;
     std::list<BleFingerprint *> fingerprints;

--- a/lib/BleFingerprint/BleFingerprintCollection.h
+++ b/lib/BleFingerprint/BleFingerprintCollection.h
@@ -18,8 +18,7 @@ public:
     }
     BleFingerprint *getFingerprint(BLEAdvertisedDevice *advertisedDevice);
     void cleanupOldFingerprints();
-    int getTotalAdverts() { return _totalSeen; }
-    std::list<BleFingerprint *> getSeen();
+    std::list<BleFingerprint *> getCopy();
     void setDisable(bool disable) { _disable = disable; }
     void setParams(int rssiRef, int forgetMs, float skipDistance, int skipMs, float maxDistance)
     {
@@ -35,7 +34,6 @@ public:
 
 private:
     bool _disable = false;
-    int _totalSeen = 0;
 
     float _maxDistance, _skipDistance;
     int _refRssi, _forgetMs, _skipMs;
@@ -46,7 +44,6 @@ private:
 
     void onResult(BLEAdvertisedDevice *advertisedDevice)
     {
-        _totalSeen++;
         if (_disable) return;
 
         Display.seenStart();

--- a/lib/BleFingerprint/strings.cpp
+++ b/lib/BleFingerprint/strings.cpp
@@ -1,6 +1,5 @@
-#ifndef STRINGS_h
-#define STRINGS_h
 #include <regex>
+#include <strings.h>
 
 std::string lowertrim(std::string str, char c)
 {
@@ -57,4 +56,21 @@ String kebabify(String text)
     std::string s = std::string(text.c_str());
     return kebabify(s).c_str();
 }
-#endif
+
+std::string hexStr(const char *data, int len)
+{
+    constexpr char hexmap[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+    std::string s(len * 2, ' ');
+    for (int i = 0; i < len; ++i)
+    {
+        s[2 * i] = hexmap[(data[i] & 0xF0) >> 4];
+        s[2 * i + 1] = hexmap[data[i] & 0x0F];
+    }
+    return s;
+}
+
+std::string hexStr(std::string s)
+{
+    return hexStr(s.c_str(), s.length());
+}

--- a/lib/BleFingerprint/strings.h
+++ b/lib/BleFingerprint/strings.h
@@ -1,0 +1,12 @@
+#ifndef STRINGS_h
+#define STRINGS_h
+
+#include <Arduino.h>
+
+std::string slugify(std::string text);
+String slugify(String text);
+std::string kebabify(std::string text);
+String kebabify(String text);
+std::string hexStr(const char *data, int len);
+std::string hexStr(std::string s);
+#endif

--- a/lib/BleFingerprint/util.h
+++ b/lib/BleFingerprint/util.h
@@ -13,8 +13,14 @@ static BLEUUID itagUUID((uint16_t)0xffe0);
 static BLEUUID roomAssistantService(uint32_t(0x5403c8a7), uint16_t(0x5c96), uint16_t(0x47e9), uint64_t(0x9ab859e373d875a7));
 static BLEUUID rootAssistantCharacteristic(0x21c46f33, 0xe813, 0x4407, 0x86012ad281030052);
 
+static BLEUUID genericAccessService(uint16_t(0x1800));
 static BLEUUID deviceInformationService(uint16_t(0x180A));
-static BLEUUID modelNumberCharacteristic(uint16_t(0x2A24));
+
+static BLEUUID nameChar(uint16_t(0x2A00));
+static BLEUUID manufChar(uint16_t(0x2A29));
+static BLEUUID modelChar(uint16_t(0x2A24));
+static BLEUUID hwRevChar(uint16_t(0x2A27));
+static BLEUUID fwRevChar(uint16_t(0x2A26));
 
 static int median_of_3(int a, int b, int c)
 {

--- a/lib/BleFingerprint/util.h
+++ b/lib/BleFingerprint/util.h
@@ -10,6 +10,12 @@ static BLEUUID exposureUUID((uint16_t)0xFD6F);
 static BLEUUID sonosUUID((uint16_t)0xFE07);
 static BLEUUID itagUUID((uint16_t)0xffe0);
 
+static BLEUUID roomAssistantService(uint32_t(0x5403c8a7), uint16_t(0x5c96), uint16_t(0x47e9), uint64_t(0x9ab859e373d875a7));
+static BLEUUID rootAssistantCharacteristic(0x21c46f33, 0xe813, 0x4407, 0x86012ad281030052);
+
+static BLEUUID deviceInformationService(uint16_t(0x180A));
+static BLEUUID modelNumberCharacteristic(uint16_t(0x2A24));
+
 static int median_of_3(int a, int b, int c)
 {
     int the_max = max(max(a, b), c);

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,8 @@ lib_deps_external =
 	bbx10/DNSServer@^1.1.0
 	adafruit/Adafruit Unified Sensor @ ^1.1.4
 	beegee-tokyo/DHT sensor library for ESPx @ ^1.18
+build_flags =
+	-D CONFIG_BT_NIMBLE_PINNED_TO_CORE=1
 
 [env:esp32]
 platform = espressif32

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@ bool sendTelemetry(int totalSeen, int totalFpSeen, int totalFpQueried, int total
 {
     if (!online)
     {
-        if (sendOnline() && sendDiscoveryConnectivity() && sendDiscoveryMaxDistance() && sendDiscoveryMotion() && sendDiscoveryHumidity() && sendDiscoveryTemperature())
+        if (sendOnline())
         {
             online = true;
             reconnectTries = 0;
@@ -11,6 +11,18 @@ bool sendTelemetry(int totalSeen, int totalFpSeen, int totalFpQueried, int total
         else
         {
             log_e("Error sending status=online");
+        }
+    }
+
+    if (discovery && !sentDiscovery)
+    {
+        if (sendDiscoveryConnectivity() && sendNumberDiscovery("Max Distance") && sendSwitchDiscovery("Active Scan") && sendSwitchDiscovery("Query") && sendDiscoveryMotion() && sendDiscoveryHumidity() && sendDiscoveryTemperature())
+        {
+            sentDiscovery = true;
+        }
+        else
+        {
+            log_e("Error sending discovery");
         }
     }
 
@@ -200,6 +212,19 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
     {
         maxDistance = pay.toFloat();
         spurt("/max_dist", pay);
+        online = false;
+    }
+    else if (top == roomsTopic + "/active_scan/set")
+    {
+        activeScan = pay == "ON";
+        spurt("/active_scan", String(activeScan));
+        online = false;
+    }
+    else if (top == roomsTopic + "/query/set")
+    {
+        allowQuery = pay == "ON";
+        spurt("/query", String(allowQuery));
+        online = false;
     }
 
     fingerprints.setParams(refRssi, forgetMs, skipDistance, skipMs, maxDistance);

--- a/src/main.h
+++ b/src/main.h
@@ -47,7 +47,7 @@ String roomsTopic;
 String subTopic;
 bool autoUpdate, otaUpdate;
 bool discovery;
-bool activeScan;
+bool activeScan, allowQuery;
 bool publishTele;
 bool publishRooms;
 bool publishDevices;


### PR DESCRIPTION
We can now connect to btle devices and ask for characteristics.  This means we can append the model number to all apple fingerprints.  

This also adds support for the room assistant app on iPhones which gets you a unique uuid for any phone it's installed on. 

Fixes #69 and #39!