### PR TITLE
I2C BME280 & TSL2561 support + two I2C buses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Settings_*.h
 .scripts
 .DS_Store
 cmake-build-*
+build/

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ default_envs = esp32
 [common_env_data]
 platform = espressif32
 framework = arduino
-lib_deps_external =
+lib_deps_external = 
 	haimoz/SoftFilters@^0.1.0
 	marvinroger/AsyncMqttClient@^0.9.0
 	bblanchon/ArduinoJson@^6.17.3
@@ -25,30 +25,34 @@ lib_deps_external =
 	adafruit/Adafruit Unified Sensor @ ^1.1.4
 	beegee-tokyo/DHT sensor library for ESPx @ ^1.18
 	starmbi/hp_BH1750 @ ^1.0.0
-build_flags =
+build_flags = 
 	-D CONFIG_BT_NIMBLE_PINNED_TO_CORE=1
 
 [env:esp32]
 platform = ${common_env_data.platform}
 framework = ${common_env_data.framework}
 board = esp32dev
-lib_deps = ${common_env_data.lib_deps_external}
+lib_deps = 
+	${common_env_data.lib_deps_external}
+	adafruit/Adafruit BME280 Library@^2.2.2
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 upload_speed = 115200
 monitor_filters = esp32_exception_decoder
-build_flags =
+build_flags = 
 	-D FIRMWARE='"esp32"'
 
 [env:adafruit-huzzah32]
 platform = ${common_env_data.platform}
 framework = ${common_env_data.framework}
 board = esp32dev
-lib_deps = ${common_env_data.lib_deps_external}
+lib_deps = 
+	${common_env_data.lib_deps_external}
+	adafruit/Adafruit BME280 Library@^2.2.2
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
-build_flags =
+build_flags = 
 	-D FIRMWARE='"adafruit-huzzah32"'
 	-D HUZZAH32
 
@@ -56,12 +60,14 @@ build_flags =
 platform = ${common_env_data.platform}
 framework = ${common_env_data.framework}
 board = esp32dev
-lib_deps = ${common_env_data.lib_deps_external}
+lib_deps = 
+	${common_env_data.lib_deps_external}
+	adafruit/Adafruit BME280 Library@^2.2.2
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 upload_speed = 1500000
 monitor_filters = esp32_exception_decoder
-build_flags =
+build_flags = 
 	-D CORE_DEBUG_LEVEL=2
 	-D FIRMWARE='"esp32-verbose"'
 	-D VERBOSE
@@ -70,13 +76,14 @@ build_flags =
 platform = ${common_env_data.platform}
 framework = ${common_env_data.framework}
 board = m5stick-c
-lib_deps =
+lib_deps = 
 	m5stack/M5StickC@^0.2.0
 	${common_env_data.lib_deps_external}
+	adafruit/Adafruit BME280 Library@^2.2.2
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
-build_flags =
+build_flags = 
 	-D M5STICK
 	-D FIRMWARE='"m5stickc"'
 
@@ -84,13 +91,14 @@ build_flags =
 platform = ${common_env_data.platform}
 framework = ${common_env_data.framework}
 board = m5stick-c
-lib_deps =
+lib_deps = 
 	m5stack/M5StickCPlus@^0.0.2
 	${common_env_data.lib_deps_external}
+	adafruit/Adafruit BME280 Library@^2.2.2
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
-build_flags =
+build_flags = 
 	-D M5STICK
 	-D PLUS
 	-D FIRMWARE='"m5stickc-plus"'
@@ -99,14 +107,15 @@ build_flags =
 platform = ${common_env_data.platform}
 framework = ${common_env_data.framework}
 board = m5stack-atom
-lib_deps =
+lib_deps = 
 	fastled/FastLED@^3.4.0
 	m5stack/m5atom@^0.0.5
 	${common_env_data.lib_deps_external}
+	adafruit/Adafruit BME280 Library@^2.2.2
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
-build_flags =
+build_flags = 
 	-D M5ATOM
 	-D MATRIX
 	-D FIRMWARE='"m5atom-matrix"'
@@ -115,9 +124,11 @@ build_flags =
 platform = ${common_env_data.platform}
 framework = ${common_env_data.framework}
 board = esp32dev
-lib_deps = ${common_env_data.lib_deps_external}
+lib_deps = 
+	${common_env_data.lib_deps_external}
+	adafruit/Adafruit BME280 Library@^2.2.2
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
-build_flags =
+build_flags = 
 	-D MACCHINA_A0
 	-D FIRMWARE='"macchina-a0"'

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,6 +30,8 @@ lib_deps_external =
 	adafruit/Adafruit Unified Sensor @ ^1.1.4
 	beegee-tokyo/DHT sensor library for ESPx @ ^1.18
 	starmbi/hp_BH1750 @ ^1.0.0
+	adafruit/Adafruit BME280 Library@^2.2.2
+	adafruit/Adafruit TSL2561@^1.1.0
 
 [env:esp32]
 platform = ${common_env_data.platform}
@@ -37,8 +39,6 @@ framework = ${common_env_data.framework}
 board = esp32dev
 lib_deps = 
 	${common_env_data.lib_deps_external}
-	adafruit/Adafruit BME280 Library@^2.2.2
-	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 upload_speed = 1500000
@@ -52,8 +52,6 @@ framework = ${common_env_data.framework}
 board = esp32dev
 lib_deps = 
 	${common_env_data.lib_deps_external}
-	adafruit/Adafruit BME280 Library@^2.2.2
-	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
@@ -67,8 +65,6 @@ framework = ${common_env_data.framework}
 board = esp32dev
 lib_deps = 
 	${common_env_data.lib_deps_external}
-	adafruit/Adafruit BME280 Library@^2.2.2
-	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 upload_speed = 1500000
@@ -85,8 +81,6 @@ board = m5stick-c
 lib_deps = 
 	m5stack/M5StickC@^0.2.0
 	${common_env_data.lib_deps_external}
-	adafruit/Adafruit BME280 Library@^2.2.2
-	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
@@ -101,8 +95,6 @@ board = m5stick-c
 lib_deps = 
 	m5stack/M5StickCPlus@^0.0.2
 	${common_env_data.lib_deps_external}
-	adafruit/Adafruit BME280 Library@^2.2.2
-	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
@@ -119,8 +111,6 @@ lib_deps =
 	fastled/FastLED@^3.4.0
 	m5stack/m5atom@^0.0.5
 	${common_env_data.lib_deps_external}
-	adafruit/Adafruit BME280 Library@^2.2.2
-	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
@@ -135,8 +125,6 @@ framework = ${common_env_data.framework}
 board = esp32dev
 lib_deps = 
 	${common_env_data.lib_deps_external}
-	adafruit/Adafruit BME280 Library@^2.2.2
-	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 build_flags = 

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,6 +35,7 @@ board = esp32dev
 lib_deps = 
 	${common_env_data.lib_deps_external}
 	adafruit/Adafruit BME280 Library@^2.2.2
+	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 upload_speed = 115200
@@ -49,6 +50,7 @@ board = esp32dev
 lib_deps = 
 	${common_env_data.lib_deps_external}
 	adafruit/Adafruit BME280 Library@^2.2.2
+	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
@@ -63,6 +65,7 @@ board = esp32dev
 lib_deps = 
 	${common_env_data.lib_deps_external}
 	adafruit/Adafruit BME280 Library@^2.2.2
+	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 upload_speed = 1500000
@@ -80,6 +83,7 @@ lib_deps =
 	m5stack/M5StickC@^0.2.0
 	${common_env_data.lib_deps_external}
 	adafruit/Adafruit BME280 Library@^2.2.2
+	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
@@ -95,6 +99,7 @@ lib_deps =
 	m5stack/M5StickCPlus@^0.0.2
 	${common_env_data.lib_deps_external}
 	adafruit/Adafruit BME280 Library@^2.2.2
+	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
@@ -112,6 +117,7 @@ lib_deps =
 	m5stack/m5atom@^0.0.5
 	${common_env_data.lib_deps_external}
 	adafruit/Adafruit BME280 Library@^2.2.2
+	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
@@ -127,6 +133,7 @@ board = esp32dev
 lib_deps = 
 	${common_env_data.lib_deps_external}
 	adafruit/Adafruit BME280 Library@^2.2.2
+	adafruit/Adafruit TSL2561@^1.1.0
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 build_flags = 

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -48,6 +48,9 @@
 #define DEFAULT_I2C_BUS_1_SCL 22
 #define DEFAULT_I2C_BUS 1
 
+// TSL2561 Defaults
+#define DEFAULT_TSL2561_I2C_GAIN "auto"
+
 #ifdef VERSION
 #define DEFAULT_AUTO_UPDATE true
 #define DEFAULT_OTA_UPDATE false

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -43,6 +43,11 @@
 // Number of seconds between update checks
 #define CHECK_FOR_UPDATES_INTERVAL 300
 
+// I2C Defaults
+#define DEFAULT_I2C_BUS_1_SDA 21
+#define DEFAULT_I2C_BUS_1_SCL 22
+#define DEFAULT_I2C_BUS 1
+
 #ifdef VERSION
 #define DEFAULT_AUTO_UPDATE true
 #define DEFAULT_OTA_UPDATE false

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -617,8 +617,6 @@ void luxLoop()
 
 void bme280Loop() {
 
-    if (!BME280_I2c) return;
-
     if (BME280_I2c == "0x76") {
         BME280_status = BME280.begin(0x76);
     } else if (BME280_I2c == "0x77") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,9 +143,9 @@ void connectToWifi()
     dht11Pin = WiFiSettings.integer("dht11_pin", 0, "DHT11 sensor pin (0 for disable)");
     dht22Pin = WiFiSettings.integer("dht22_pin", 0, "DHT22 sensor pin (0 for disable)");
 
-    BH1750_I2c = WiFiSettings.string("BH1750_I2c", "", "Ambient Light Sensor - I2C address of BH1750 Sensor, like 0x23 or 0x5C.");
-    BME280_I2c = WiFiSettings.string("BME280_I2c", "", "Weather Sensor - I2C address of BME280 Sensor, like 0x76 or 0x77.");
-    I2CDebug = WiFiSettings.checkbox("I2CDebug", false, "Debug I2C address. Look at the serial log to get the correct address.");
+    BH1750_I2c = WiFiSettings.string("BH1750_I2c", "", "Ambient Light Sensor - I2C address of BH1750 Sensor, like 0x23 or 0x5C");
+    BME280_I2c = WiFiSettings.string("BME280_I2c", "", "Weather Sensor - I2C address of BME280 Sensor, like 0x76 or 0x77");
+    I2CDebug = WiFiSettings.checkbox("I2CDebug", false, "Debug I2C address. Look at the serial log to get the correct address");
 
     WiFiSettings.hostname = "espresense-" + kebabify(room);
 

--- a/src/main.h
+++ b/src/main.h
@@ -59,8 +59,6 @@ String TSL2561_I2c;
 int TSL2561_I2c_Bus;
 String TSL2561_I2c_Gain;
 unsigned long tsl2561PreviousMillis = 0;
-
-bool I2CDebug;
 #endif
 
 AsyncMqttClient mqttClient;

--- a/src/main.h
+++ b/src/main.h
@@ -32,6 +32,8 @@ int I2C_Bus_2_SDA;
 int I2C_Bus_2_SCL;
 bool I2CDebug;
 
+unsigned long sensorInterval = 60000;
+
 //GY-302 lux sensor
 #include <hp_BH1750.h>
 hp_BH1750 BH1750;
@@ -47,12 +49,14 @@ Adafruit_BME280 BME280;
 long BME280_status;
 String BME280_I2c;
 int BME280_I2c_Bus;
+unsigned long bme280PreviousMillis = 0;
 
 //I2C TSL2561 sensor
 #include <Adafruit_TSL2561_U.h>
 String TSL2561_I2c;
 int TSL2561_I2c_Bus;
 String TSL2561_I2c_Gain;
+unsigned long tsl2561PreviousMillis = 0;
 
 AsyncMqttClient mqttClient;
 TimerHandle_t reconnectTimer;

--- a/src/main.h
+++ b/src/main.h
@@ -24,21 +24,29 @@
 #include <freertos/timers.h>
 #include <rom/rtc.h>
 
-//GY-302 lux sensor
+// I2C
 #include <Wire.h>
+int I2C_Bus_1_SDA;
+int I2C_Bus_1_SCL;
+int I2C_Bus_2_SDA;
+int I2C_Bus_2_SCL;
+bool I2CDebug;
+
+//GY-302 lux sensor
 #include <hp_BH1750.h>
 hp_BH1750 BH1750;
 long ms_BH1750;
 float lux_BH1750;
 int lux_BH1750_MQTT;
 String BH1750_I2c;
-bool I2CDebug;
+int BH1750_I2c_Bus;
 
 //I2C BME280 sensor
 #include <Adafruit_BME280.h>
 Adafruit_BME280 BME280;
 long BME280_status;
 String BME280_I2c;
+int BME280_I2c_Bus;
 
 
 AsyncMqttClient mqttClient;

--- a/src/main.h
+++ b/src/main.h
@@ -52,6 +52,7 @@ int BME280_I2c_Bus;
 #include <Adafruit_TSL2561_U.h>
 String TSL2561_I2c;
 int TSL2561_I2c_Bus;
+String TSL2561_I2c_Gain;
 
 AsyncMqttClient mqttClient;
 TimerHandle_t reconnectTimer;

--- a/src/main.h
+++ b/src/main.h
@@ -48,6 +48,10 @@ long BME280_status;
 String BME280_I2c;
 int BME280_I2c_Bus;
 
+//I2C TSL2561 sensor
+#include <Adafruit_TSL2561_U.h>
+String TSL2561_I2c;
+int TSL2561_I2c_Bus;
 
 AsyncMqttClient mqttClient;
 TimerHandle_t reconnectTimer;
@@ -550,6 +554,35 @@ bool sendDiscoveryBME280Pressure()
             return true;
         delay(50);
     }
+    return false;
+}
+
+bool sendDiscoveryTSL2561Lux()
+{
+    if (TSL2561_I2c.isEmpty()) return true;
+
+    DynamicJsonDocument doc(1200);
+    commonDiscovery(&doc);
+    doc["~"] = roomsTopic;
+    doc["name"] = "ESPresense " + room + " TSL2561 Lux";
+    doc["uniq_id"] = Sprintf("espresense_%06" PRIx64 "_tsl2561_lux", ESP.getEfuseMac() >> 24);
+    doc["avty_t"] = "~/status";
+    doc["stat_t"] = "~/tsl2561_lux";
+    doc["dev_cla"] = "illuminance";
+    doc["unit_of_meas"] = "lx";
+    doc["frc_upd"] = true;
+
+    char buffer[1200];
+    serializeJson(doc, buffer);
+    String discoveryTopic = "homeassistant/sensor/espresense_" + ESPMAC + "/tsl2561_lux/config";
+
+    for (int i = 0; i < 10; i++)
+    {
+        if (mqttClient.publish(discoveryTopic.c_str(), 0, true, buffer))
+            return true;
+        delay(50);
+    }
+
     return false;
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -34,6 +34,13 @@ int lux_BH1750_MQTT;
 String BH1750_I2c;
 bool I2CDebug;
 
+//I2C BME280 sensor
+#include <Adafruit_BME280.h>
+Adafruit_BME280 BME280;
+long BME280_status;
+String BME280_I2c;
+
+
 AsyncMqttClient mqttClient;
 TimerHandle_t reconnectTimer;
 TaskHandle_t scannerTask;
@@ -453,6 +460,91 @@ bool sendDiscoveryLux()
 
     return false;
 }
+
+bool sendDiscoveryBME280Temperature()
+{
+    if (!BME280_I2c) return true;
+
+    DynamicJsonDocument doc(1200);
+    commonDiscovery(&doc);
+    doc["~"] = roomsTopic;
+    doc["name"] = "ESPresense " + room + " BME280 Temperature";
+    doc["uniq_id"] = Sprintf("espresense_%06" PRIx64 "_bme280_temperature", ESP.getEfuseMac() >> 24);
+    doc["avty_t"] = "~/status";
+    doc["stat_t"] = "~/bme280_temperature";
+    doc["dev_cla"] = "temperature";
+    doc["unit_of_meas"] = "°C";
+    doc["frc_upd"] = true;
+
+    char buffer[1200];
+    serializeJson(doc, buffer);
+    String discoveryTopic = "homeassistant/sensor/espresense_" + ESPMAC + "/bme280_temperature/config";
+
+    for (int i = 0; i < 10; i++)
+    {
+        if (mqttClient.publish(discoveryTopic.c_str(), 0, true, buffer))
+            return true;
+        delay(50);
+    }
+    return false;
+}
+
+bool sendDiscoveryBME280Humidity()
+{
+    if (!BME280_I2c) return true;
+
+    DynamicJsonDocument doc(1200);
+    commonDiscovery(&doc);
+    doc["~"] = roomsTopic;
+    doc["name"] = "ESPresense " + room + " BME280 Humidity";
+    doc["uniq_id"] = Sprintf("espresense_%06" PRIx64 "_bme280_humidity", ESP.getEfuseMac() >> 24);
+    doc["avty_t"] = "~/status";
+    doc["stat_t"] = "~/bme280_humidity";
+    doc["dev_cla"] = "humidity";
+    doc["unit_of_meas"] = "%";
+    doc["frc_upd"] = true;
+
+    char buffer[1200];
+    serializeJson(doc, buffer);
+    String discoveryTopic = "homeassistant/sensor/espresense_" + ESPMAC + "/bme280_humidity/config";
+
+    for (int i = 0; i < 10; i++)
+    {
+        if (mqttClient.publish(discoveryTopic.c_str(), 0, true, buffer))
+            return true;
+        delay(50);
+    }
+    return false;
+}
+
+bool sendDiscoveryBME280Pressure()
+{
+    if (!BME280_I2c) return true;
+
+    DynamicJsonDocument doc(1200);
+    commonDiscovery(&doc);
+    doc["~"] = roomsTopic;
+    doc["name"] = "ESPresense " + room + " BME280 Pressure";
+    doc["uniq_id"] = Sprintf("espresense_%06" PRIx64 "_bme280_pressure", ESP.getEfuseMac() >> 24);
+    doc["avty_t"] = "~/status";
+    doc["stat_t"] = "~/bme280_pressure";
+    doc["dev_cla"] = "pressure";
+    doc["unit_of_meas"] = "hPa";
+    doc["frc_upd"] = true;
+
+    char buffer[1200];
+    serializeJson(doc, buffer);
+    String discoveryTopic = "homeassistant/sensor/espresense_" + ESPMAC + "/bme280_pressure/config";
+
+    for (int i = 0; i < 10; i++)
+    {
+        if (mqttClient.publish(discoveryTopic.c_str(), 0, true, buffer))
+            return true;
+        delay(50);
+    }
+    return false;
+}
+
 
 bool sendSwitchDiscovery(String name, String entityCategory)
 {

--- a/src/main.h
+++ b/src/main.h
@@ -500,7 +500,6 @@ bool sendDiscoveryLux()
     String discoveryTopic = "homeassistant/sensor/espresense_" + ESPMAC + "/lux/config";
     return pub(discoveryTopic.c_str(), 0, true, buffer);
 }
-#endif
 
 bool sendDiscoveryBME280Temperature()
 {
@@ -614,6 +613,7 @@ bool sendDiscoveryTSL2561Lux()
 
     return false;
 }
+#endif
 
 
 bool sendSwitchDiscovery(String name, String entityCategory)

--- a/src/main.h
+++ b/src/main.h
@@ -463,7 +463,7 @@ bool sendDiscoveryLux()
 
 bool sendDiscoveryBME280Temperature()
 {
-    if (!BME280_I2c) return true;
+    if (BME280_I2c.isEmpty()) return true;
 
     DynamicJsonDocument doc(1200);
     commonDiscovery(&doc);
@@ -491,7 +491,7 @@ bool sendDiscoveryBME280Temperature()
 
 bool sendDiscoveryBME280Humidity()
 {
-    if (!BME280_I2c) return true;
+    if (BME280_I2c.isEmpty()) return true;
 
     DynamicJsonDocument doc(1200);
     commonDiscovery(&doc);
@@ -519,7 +519,7 @@ bool sendDiscoveryBME280Humidity()
 
 bool sendDiscoveryBME280Pressure()
 {
-    if (!BME280_I2c) return true;
+    if (BME280_I2c.isEmpty()) return true;
 
     DynamicJsonDocument doc(1200);
     commonDiscovery(&doc);


### PR DESCRIPTION
Adds support for the I2C version of the BME280 and TSL2561 sensors as well as support for two I2C buses.

![image](https://user-images.githubusercontent.com/13995143/147697495-5cb46ca3-55f2-4abe-9bbc-9238982fc530.png)

![image](https://user-images.githubusercontent.com/13995143/147833610-0a9f3367-0ef0-42fb-a1bb-d06abf589df4.png)

More info: 
- BME280: https://www.bosch-sensortec.com/products/environmental-sensors/humidity-sensors-bme280/
- TSL2561: https://ams.com/en/tsl2561