### PR TITLE
feat: add vanmoof fingerprinting

### DIFF
--- a/lib/BleFingerprint/BleFingerprint.cpp
+++ b/lib/BleFingerprint/BleFingerprint.cpp
@@ -128,6 +128,11 @@ void BleFingerprint::fingerprint(BLEAdvertisedDevice *advertisedDevice)
             asRssi = advertisedDevice->haveTXPower() ? _parent->getRefRssi() + advertisedDevice->getTXPower() : NO_RSSI;
             setId("trackr:" + getMac(), ID_TYPE_TRACKR);
         }
+        else if (advertisedDevice->isAdvertisingService(vanmoofUUID))
+        {
+            asRssi = advertisedDevice->haveTXPower() ? _parent->getRefRssi() + advertisedDevice->getTXPower() : NO_RSSI;
+            setId("vanmoof:" + getMac(), ID_TYPE_VANMOOF);
+        }
         else if (advertisedDevice->isAdvertisingService(meaterService))
         {
             asRssi = advertisedDevice->haveTXPower() ? _parent->getRefRssi() + advertisedDevice->getTXPower() : NO_RSSI;

--- a/lib/BleFingerprint/BleFingerprint.h
+++ b/lib/BleFingerprint/BleFingerprint.h
@@ -28,6 +28,7 @@
 #define ID_TYPE_TRACKR short(18)
 #define ID_TYPE_TILE short(19)
 #define ID_TYPE_MEATER short(20)
+#define ID_TYPE_VANMOOF short(21)
 #define ID_TYPE_APPLE_NEARBY short(35)
 #define ID_TYPE_APPLE_MODEL short(40)
 #define ID_TYPE_APPLE_NAME short(50)

--- a/lib/BleFingerprint/util.h
+++ b/lib/BleFingerprint/util.h
@@ -11,7 +11,7 @@ static BLEUUID sonosUUID((uint16_t)0xFE07);
 static BLEUUID itagUUID((uint16_t)0xffe0);
 static BLEUUID miThermUUID(uint16_t(0x181A));
 static BLEUUID trackrUUID((uint16_t)0x0F3E);
-static BLEUUID vanmoofUUID("6acc5540-e631-4069-944d-b8ca7598ad50");
+static BLEUUID vanmoofUUID(0x6acc5540, 0xe631, 0x4069, 0x944db8ca7598ad50);
 
 static BLEUUID fitbitUUID(0xadabfb00, 0x6e7d, 0x4601, 0xbda2bffaa68956ba);
 

--- a/lib/BleFingerprint/util.h
+++ b/lib/BleFingerprint/util.h
@@ -11,6 +11,7 @@ static BLEUUID sonosUUID((uint16_t)0xFE07);
 static BLEUUID itagUUID((uint16_t)0xffe0);
 static BLEUUID miThermUUID(uint16_t(0x181A));
 static BLEUUID trackrUUID((uint16_t)0x0F3E);
+static BLEUUID vanmoofUUID("6acc5540-e631-4069-944d-b8ca7598ad50");
 
 static BLEUUID fitbitUUID(0xadabfb00, 0x6e7d, 0x4601, 0xbda2bffaa68956ba);
 


### PR DESCRIPTION
Adding Vanmoof bicycle fingerprinting. Tested with an S3 and X3. Using MAC address since it seems like it doesn't change.