### PR TITLE
Include Humidity for discovered sensor

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -445,6 +445,7 @@ bool sendDiscoveryHumidity()
     doc["avty_t"] = "~/status";
     doc["stat_t"] = "~/humidity";
     doc["dev_cla"] = "humidity";
+    doc["unit_of_meas"] = "%";
     doc["frc_upd"] = true;
 
     serializeJson(doc, buffer);


### PR DESCRIPTION
Adding UOM for humidity to be consistent with other published sensors. Also allows senor to draw correct graph in HA.