### PR TITLE
Bump platform version to 3.5

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ build_flags =
 	-D CONFIG_BT_NIMBLE_ROLE_BROADCASTER_DISABLED
 	-D CONFIG_ASYNC_TCP_USE_WDT=0
 	-D CONFIG_USE_ETHERNET
-platform = espressif32@3.2
+platform = espressif32@3.5
 framework = arduino
 lib_deps =
 	haimoz/SoftFilters@^0.1.0


### PR DESCRIPTION
Bump the platform version for the ESP32 libraries. Compiles and runs with current master branch, there have been several bugfixes in the underlying platformio  framework