### PR TITLE
Add support for `nut` type tags

### DIFF
--- a/lib/BleFingerprint/BleFingerprint.cpp
+++ b/lib/BleFingerprint/BleFingerprint.cpp
@@ -158,6 +158,12 @@ void BleFingerprint::fingerprintServiceAdvertisements(NimBLEAdvertisedDevice *ad
             setId("meater:" + getMac(), ID_TYPE_MEATER);
             return;
         }
+        else if (uuid == nutUUID)
+        {
+            asRssi = BleFingerprintCollection::refRssi + (haveTxPower ? txPower : NUT_TX);
+            setId("nut:" + getMac(), ID_TYPE_NUT);
+            return;
+        }
     }
 
     String fingerprint = "ad:";

--- a/lib/BleFingerprint/BleFingerprint.h
+++ b/lib/BleFingerprint/BleFingerprint.h
@@ -44,6 +44,7 @@
 #define ID_TYPE_IBEACON short(175)
 #define ID_TYPE_RM_ASST short(180)
 #define ID_TYPE_KNOWN_MAC short(185)
+#define ID_TYPE_NUT short(190)
 
 class BleFingerprintCollection;
 

--- a/lib/BleFingerprint/rssi.h
+++ b/lib/BleFingerprint/rssi.h
@@ -12,5 +12,7 @@
 #define EXPOSURE_TX (-12)
 #define ITAG_TX (-10)
 
+#define NUT_TX (-12)
+
 #define EDDYSTONE_ADD_1M (-41)
 #endif

--- a/lib/BleFingerprint/util.h
+++ b/lib/BleFingerprint/util.h
@@ -14,6 +14,8 @@ static BLEUUID miThermUUID(uint16_t(0x181A));
 static BLEUUID trackrUUID((uint16_t)0x0F3E);
 static BLEUUID vanmoofUUID(0x6acc5540, 0xe631, 0x4069, 0x944db8ca7598ad50);
 
+static BLEUUID nutUUID((uint16_t)0x1803);
+
 static BLEUUID fitbitUUID(0xadabfb00, 0x6e7d, 0x4601, 0xbda2bffaa68956ba);
 
 static BLEUUID roomAssistantService(0x5403c8a7, 0x5c96, 0x47e9, 0x9ab859e373d875a7);


### PR DESCRIPTION
This patch adds support for tags which all report themselves as having
the same identifier: `name:nut`, but do all have distinct unchanging MAC
addresses.  The patch changes the reported ID to be `nut:<mac address>`.

Fixes #466.