### PR TITLE
Prevent BME280 from overheating

### DIFF
--- a/src/BME280Sensor.cpp
+++ b/src/BME280Sensor.cpp
@@ -1,7 +1,7 @@
 #ifdef SENSORS
 
 #include "defaults.h"
-#include "TSL2561Sensor.h"
+#include "BME280Sensor.h"
 #include <WiFiSettings.h>
 #include <AsyncMqttClient.h>
 #include <Adafruit_BME280.h>

--- a/src/BME280Sensor.cpp
+++ b/src/BME280Sensor.cpp
@@ -73,8 +73,7 @@ namespace BME280
             Adafruit_BME280::SAMPLING_X1,  // Pressure
             Adafruit_BME280::SAMPLING_X1,  // Humidity
             //Adafruit_BME280::FILTER_X16,
-            Adafruit_BME280::FILTER_OFF,
-            Adafruit_BME280::STANDBY_MS_60000
+            Adafruit_BME280::FILTER_OFF
         );
 
         float temperature = BME280.readTemperature();

--- a/src/BME280Sensor.cpp
+++ b/src/BME280Sensor.cpp
@@ -68,13 +68,13 @@ namespace BME280
         }
 
         BME280.setSampling(
-            Adafruit_BME280::MODE_NORMAL,
-            Adafruit_BME280::SAMPLING_X16,  // Temperature
-            Adafruit_BME280::SAMPLING_X16,  // Pressure
-            Adafruit_BME280::SAMPLING_X16,  // Humidity
-            Adafruit_BME280::FILTER_X16,
-            //Adafruit_BME280::FILTER_OFF,
-            Adafruit_BME280::STANDBY_MS_1000
+            Adafruit_BME280::MODE_FORCED,
+            Adafruit_BME280::SAMPLING_X1,  // Temperature
+            Adafruit_BME280::SAMPLING_X1,  // Pressure
+            Adafruit_BME280::SAMPLING_X1,  // Humidity
+            //Adafruit_BME280::FILTER_X16,
+            Adafruit_BME280::FILTER_OFF,
+            Adafruit_BME280::STANDBY_MS_60000
         );
 
         float temperature = BME280.readTemperature();

--- a/src/HX711.cpp
+++ b/src/HX711.cpp
@@ -1,7 +1,7 @@
 #ifdef SENSORS
 
 #include "defaults.h"
-#include "TSL2561Sensor.h"
+#include "HX711.h"
 #include <WiFiSettings.h>
 #include <AsyncMqttClient.h>
 


### PR DESCRIPTION
After running this for a while, I noticed that both ESPresense instances I had with BME280 sensors were constantly showing 8C above what my ESPHome sensor was showing.

I later learned that Bosch recommended to set oversampling to 1x, enable "Forced mode" and disable the filter (for weather monitoring) to prevent overheating.
(My ESPHome instances also use those settings)

![image](https://user-images.githubusercontent.com/13995143/170321032-912b9819-b09e-45d2-a960-6bd8d0ec1107.png)

This change will also result in a much lower power consumption