### PR TITLE
Remove huzzah flavor, make all variants sensor enabled, m5atom-matrix renamed m5atom

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,25 +37,28 @@ jobs:
       run: echo "PLATFORMIO_BUILD_FLAGS=-DVERSION='\"${GITHUB_REF#refs/*/}\"'" >> $GITHUB_ENV
       if: startsWith(github.ref, 'refs/tags/v')
     - name: Run PlatformIO
-      run: pio run -e esp32 -e esp32-verbose -e adafruit-huzzah32 -e m5stickc -e m5stickc-plus -e m5atom-matrix -e esp32-sensors -e esp32-verbose-sensors -e adafruit-huzzah32-sensors -e m5stickc-sensors -e m5stickc-plus-sensors -e m5atom-matrix-sensors -e macchina-a0 -e esp32c3
+      run: pio run -e esp32 -e esp32c3 -e esp32-verbose -e m5stickc -e m5stickc-plus -e m5atom -e macchina-a0
     - name: Rename firmware
       run: |
         cp .pio/build/esp32/firmware.bin esp32.bin
+        cp .pio/build/esp32c3/firmware.bin esp32c3.bin
         cp .pio/build/esp32-verbose/firmware.bin esp32-verbose.bin
-        cp .pio/build/adafruit-huzzah32/firmware.bin adafruit-huzzah32.bin
         cp .pio/build/m5stickc/firmware.bin m5stickc.bin
         cp .pio/build/m5stickc-plus/firmware.bin m5stickc-plus.bin
-        cp .pio/build/m5atom-matrix/firmware.bin m5atom-matrix.bin
-
-        cp .pio/build/esp32-sensors/firmware.bin esp32-sensors.bin
-        cp .pio/build/esp32-verbose-sensors/firmware.bin esp32-verbose-sensors.bin
-        cp .pio/build/adafruit-huzzah32-sensors/firmware.bin adafruit-huzzah32-sensors.bin
-        cp .pio/build/m5stickc-sensors/firmware.bin m5stickc-sensors.bin
-        cp .pio/build/m5stickc-plus-sensors/firmware.bin m5stickc-plus-sensors.bin
-        cp .pio/build/m5atom-matrix-sensors/firmware.bin m5atom-matrix-sensors.bin
-
-        cp .pio/build/esp32c3/firmware.bin esp32c3.bin
+        cp .pio/build/m5atom/firmware.bin m5atom.bin
         cp .pio/build/macchina-a0/firmware.bin macchina-a0.bin
+
+        #Deprecated
+        cp .pio/build/m5atom/firmware.bin m5atom-matrix.bin
+        cp .pio/build/m5atom/firmware.bin m5atom-matrix-sensors.bin
+        cp .pio/build/esp32/firmware.bin adafruit-huzzah32.bin
+        cp .pio/build/esp32/firmware.bin adafruit-huzzah32-sensors.bin
+
+        #Deprecated Sensors
+        cp .pio/build/esp32/firmware.bin esp32-sensors.bin
+        cp .pio/build/esp32-verbose/firmware.bin esp32-verbose-sensors.bin
+        cp .pio/build/m5stickc/firmware.bin m5stickc-sensors.bin
+        cp .pio/build/m5stickc-plus/firmware.bin m5stickc-plus-sensors.bin
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/v')

--- a/lib/BleFingerprint/GUI.cpp
+++ b/lib/BleFingerprint/GUI.cpp
@@ -17,11 +17,6 @@
 #define BUTTON 39
 #define BUTTON_PRESSED 0
 
-#elif defined HUZZAH32
-
-#define LED_BUILTIN 13
-#define LED_BUILTIN_ON 1
-
 #else //DevKit / generic
 
 #define LED_BUILTIN 2

--- a/platformio.ini
+++ b/platformio.ini
@@ -68,7 +68,7 @@ build_flags = -g
   ${common.build_flags}
 lib_deps = ${common.lib_deps}
 
-[common_sensors]
+[sensors]
 lib_deps =
 	adafruit/Adafruit Unified Sensor @ ^1.1.4
 	beegee-tokyo/DHT sensor library for ESPx @ ^1.18
@@ -81,7 +81,9 @@ platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 framework = ${esp32.framework}
 board = esp32dev
-lib_deps = ${esp32.lib_deps}
+lib_deps =
+	${esp32.lib_deps}
+	${sensors.lib_deps}
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 upload_speed = 1500000
@@ -89,6 +91,7 @@ monitor_filters = esp32_exception_decoder, time
 build_unflags = ${esp32.build_unflags}
 build_flags =
 	-D FIRMWARE='"esp32"'
+	-D SENSORS
 	${esp32.build_flags}
 
 [env:esp32c3]
@@ -100,33 +103,23 @@ board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 upload_speed = 1500000
 monitor_filters = esp32_exception_decoder, time
-lib_deps = ${esp32c3.lib_deps}
+lib_deps =
+	${esp32c3.lib_deps}
+	${sensors.lib_deps}
 build_unflags = ${esp32c3.build_unflags}
 build_flags =
 	-D FIRMWARE='"esp32c3"'
+	-D SENSORS
 	${esp32c3.build_flags}
-
-[env:adafruit-huzzah32]
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
-framework = ${esp32.framework}
-board = esp32dev
-lib_deps = ${esp32.lib_deps}
-board_build.partitions = partitions_singleapp.csv
-monitor_speed = 115200
-monitor_filters = esp32_exception_decoder, time
-build_unflags = ${esp32.build_unflags}
-build_flags =
-	-D FIRMWARE='"adafruit-huzzah32"'
-	-D HUZZAH32
-	${esp32.build_flags}
 
 [env:esp32-verbose]
 platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 framework = ${esp32.framework}
 board = esp32dev
-lib_deps = ${esp32.lib_deps}
+lib_deps =
+	${esp32.lib_deps}
+	${sensors.lib_deps}
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 upload_speed = 1500000
@@ -136,6 +129,7 @@ build_flags =
 	-D CORE_DEBUG_LEVEL=2
 	-D FIRMWARE='"esp32-verbose"'
 	-D VERBOSE
+	-D SENSORS
 	${esp32.build_flags}
 
 [env:m5stickc]
@@ -147,6 +141,7 @@ lib_deps =
 	m5stack/M5StickC@^0.2.0
 	https://github.com/ESPresense/M5StickC-TB_Display.git
 	${esp32.lib_deps}
+	${sensors.lib_deps}
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder, time
@@ -154,6 +149,7 @@ build_unflags = ${esp32.build_unflags}
 build_flags =
 	-D M5STICK
 	-D FIRMWARE='"m5stickc"'
+	-D SENSORS
 	${esp32.build_flags}
 
 [env:m5stickc-plus]
@@ -165,6 +161,7 @@ lib_deps =
 	m5stack/M5StickCPlus@^0.0.2
 	https://github.com/ESPresense/M5StickC-TB_Display.git
 	${esp32.lib_deps}
+	${sensors.lib_deps}
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder, time
@@ -173,9 +170,10 @@ build_flags =
 	-D M5STICK
 	-D PLUS
 	-D FIRMWARE='"m5stickc-plus"'
+	-D SENSORS
 	${esp32.build_flags}
 
-[env:m5atom-matrix]
+[env:m5atom]
 platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 framework = ${esp32.framework}
@@ -184,6 +182,7 @@ lib_deps =
 	fastled/FastLED@^3.4.0
 	m5stack/m5atom@^0.0.9
 	${esp32.lib_deps}
+	${sensors.lib_deps}
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder, time
@@ -191,7 +190,8 @@ build_unflags = ${esp32.build_unflags}
 build_flags =
 	-D M5ATOM
 	-D MATRIX
-	-D FIRMWARE='"m5atom-matrix"'
+	-D FIRMWARE='"m5atom"'
+	-D SENSORS
 	${esp32.build_flags}
 
 [env:macchina-a0]
@@ -199,129 +199,14 @@ platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 framework = ${esp32.framework}
 board = esp32dev
-lib_deps = ${esp32.lib_deps}
+lib_deps =
+	${esp32.lib_deps}
+	${sensors.lib_deps}
 board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 build_unflags = ${esp32.build_unflags}
 build_flags =
 	-D MACCHINA_A0
 	-D FIRMWARE='"macchina-a0"'
-	${esp32.build_flags}
-
-[env:esp32-sensors]
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
-framework = ${esp32.framework}
-board = esp32dev
-lib_deps =
-	${esp32.lib_deps}
-	${common_sensors.lib_deps}
-board_build.partitions = partitions_singleapp.csv
-monitor_speed = 115200
-upload_speed = 1500000
-monitor_filters = esp32_exception_decoder, time
-build_unflags = ${esp32.build_unflags}
-build_flags =
-	-D FIRMWARE='"esp32-sensors"'
-	-D SENSORS
-	${esp32.build_flags}
-
-[env:adafruit-huzzah32-sensors]
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
-framework = ${esp32.framework}
-board = esp32dev
-lib_deps =
-	${esp32.lib_deps}
-	${common_sensors.lib_deps}
-board_build.partitions = partitions_singleapp.csv
-monitor_speed = 115200
-monitor_filters = esp32_exception_decoder, time
-build_unflags = ${esp32.build_unflags}
-build_flags =
-	-D FIRMWARE='"adafruit-huzzah32-sensors"'
-	-D HUZZAH32
-	-D SENSORS
-	${esp32.build_flags}
-
-[env:esp32-verbose-sensors]
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
-framework = ${esp32.framework}
-board = esp32dev
-lib_deps =
-	${esp32.lib_deps}
-	${common_sensors.lib_deps}
-board_build.partitions = partitions_singleapp.csv
-monitor_speed = 115200
-upload_speed = 1500000
-monitor_filters = esp32_exception_decoder, time
-build_unflags = ${esp32.build_unflags}
-build_flags =
-	-D CORE_DEBUG_LEVEL=2
-	-D FIRMWARE='"esp32-verbose-sensors"'
-	-D VERBOSE
-	-D SENSORS
-	${esp32.build_flags}
-
-[env:m5stickc-sensors]
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
-framework = ${esp32.framework}
-board = m5stick-c
-lib_deps =
-	m5stack/M5StickC@^0.2.0
-	https://github.com/ESPresense/M5StickC-TB_Display.git
-	${esp32.lib_deps}
-	${common_sensors.lib_deps}
-board_build.partitions = partitions_singleapp.csv
-monitor_speed = 115200
-monitor_filters = esp32_exception_decoder, time
-build_unflags = ${esp32.build_unflags}
-build_flags =
-	-D M5STICK
-	-D FIRMWARE='"m5stickc-sensors"'
-	-D SENSORS
-	${esp32.build_flags}
-
-[env:m5stickc-plus-sensors]
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
-framework = ${esp32.framework}
-board = m5stick-c
-lib_deps =
-	m5stack/M5StickCPlus@^0.0.2
-	https://github.com/ESPresense/M5StickC-TB_Display.git
-	${esp32.lib_deps}
-	${common_sensors.lib_deps}
-board_build.partitions = partitions_singleapp.csv
-monitor_speed = 115200
-monitor_filters = esp32_exception_decoder, time
-build_unflags = ${esp32.build_unflags}
-build_flags =
-	-D M5STICK
-	-D PLUS
-	-D FIRMWARE='"m5stickc-plus-sensors"'
-	-D SENSORS
-	${esp32.build_flags}
-
-[env:m5atom-matrix-sensors]
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
-framework = ${esp32.framework}
-board = m5stack-atom
-lib_deps =
-	fastled/FastLED@^3.4.0
-	m5stack/m5atom@^0.0.9
-	${esp32.lib_deps}
-	${common_sensors.lib_deps}
-board_build.partitions = partitions_singleapp.csv
-monitor_speed = 115200
-monitor_filters = esp32_exception_decoder, time
-build_unflags = ${esp32.build_unflags}
-build_flags =
-	-D M5ATOM
-	-D MATRIX
-	-D FIRMWARE='"m5atom-matrix-sensors"'
 	-D SENSORS
 	${esp32.build_flags}


### PR DESCRIPTION
We copy firmware files to old locations so auto-updating should work just fine, but downgrading will be annoying because it'll revert to non-sensor versions.  Not sure it can be helped.  Making this part of v3.