### PR TITLE
Watchdog for ble controller

### DIFF
--- a/lib/BleFingerprint/BleFingerprintCollection.cpp
+++ b/lib/BleFingerprint/BleFingerprintCollection.cpp
@@ -87,6 +87,7 @@ void BleFingerprintCollection::cleanupOldFingerprints()
     if (now - lastCleanup < 5000) return;
     lastCleanup = now;
     auto it = fingerprints.begin();
+    bool any = false;
     while (it != fingerprints.end())
     {
         auto age = (*it)->getMsSinceLastSeen();
@@ -98,7 +99,15 @@ void BleFingerprintCollection::cleanupOldFingerprints()
         }
         else
         {
+            any = true;
             ++it;
+        }
+    }
+    if (!any) {
+        auto uptime = (unsigned long)(esp_timer_get_time() / 1000000ULL);
+        if (uptime > ALLOW_BLE_CONTROLLER_RESTART_AFTER_SECS) {
+            Serial.println("Bluetooth controller seems stuck, restarting");
+            ESP.restart();
         }
     }
 }

--- a/lib/BleFingerprint/BleFingerprintCollection.h
+++ b/lib/BleFingerprint/BleFingerprintCollection.h
@@ -8,6 +8,10 @@
 #define ONE_EURO_BETA 1e-7f
 #define ONE_EURO_DCUTOFF 1e-5f
 
+#ifndef ALLOW_BLE_CONTROLLER_RESTART_AFTER_SECS
+#define ALLOW_BLE_CONTROLLER_RESTART_AFTER_SECS 1800
+#endif
+
 class BleFingerprintCollection : public BLEAdvertisedDeviceCallbacks
 {
 public:

--- a/src/defaults.h
+++ b/src/defaults.h
@@ -33,7 +33,7 @@
 #define DEFAULT_REF_RSSI (-65)
 #define DEFAULT_ABSORPTION (3.5)
 
-#define DEFAULT_FORGET_MS 300000 // Ms to remove fingerprint after not seeing it
+#define DEFAULT_FORGET_MS 150000 // Ms to remove fingerprint after not seeing it
 
 #define DEFAULT_SKIP_DISTANCE 0.5 // If beacon has moved less than this skip update
 #define DEFAULT_SKIP_MS 5000 // Ms to skip mqtt update if no movement
@@ -41,6 +41,11 @@
 // Number of seconds between update checks
 #ifndef CHECK_FOR_UPDATES_INTERVAL
 #define CHECK_FOR_UPDATES_INTERVAL 900
+#endif
+
+// Number of seconds before attempting to reconnect to MQTT broker
+#ifndef CAPTIVE_PORTAL_TIMEOUT
+#define CAPTIVE_PORTAL_TIMEOUT 300
 #endif
 
 // I2C Defaults

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,7 +155,7 @@ void setupNetwork()
             GUI::status("WiFi Portal...");
         }
 
-        if (getUptimeSeconds() > 600)
+        if (getUptimeSeconds() > CAPTIVE_PORTAL_TIMEOUT)
             ESP.restart();
     };
     AsyncWiFiSettings.onHttpSetup = HttpServer::Init;
@@ -379,7 +379,7 @@ void reconnect(TimerHandle_t xTimer)
 
     if (reconnectTries++ > 50)
     {
-        log_e("Too many reconnect attempts; Restarting");
+        Serial.println("Too many reconnect attempts; Restarting");
         ESP.restart();
     }
 


### PR DESCRIPTION
- Reboot if no bluetooth advertisements seen in the last 2.5 minutes.  Ensure we don't reboot until after checking for an update.
- Reduce portal timeout to 5 minutes