### PR TITLE
Ensure that setting rssi@1m works after a reboot

### DIFF
--- a/lib/BleFingerprint/BleFingerprint.cpp
+++ b/lib/BleFingerprint/BleFingerprint.cpp
@@ -29,6 +29,8 @@ bool BleFingerprint::setId(const String &newId, short newIdType, const String &n
 
     DeviceConfig dc;
     if (BleFingerprintCollection::FindDeviceConfig(newId, dc)) {
+        if (dc.calRssi != NO_RSSI)
+            calRssi = dc.calRssi;
         if (!dc.alias.isEmpty())
             return setId(dc.alias, ID_TYPE_ALIAS, dc.name);
         if (!dc.name.isEmpty())


### PR DESCRIPTION
When we receive a config message from MQTT before we've seen the associated tracker we don't correctly update the rssi@1m value when we get a Bluetooth frame from the tracker later on.

This patch ensures that we correctly update the rssi@1m value.

Steps to reproduce:

1. Publish a config update for a tracker, e.g. for topic `espresense/settings/irk:00000000000000000000000000000000/config`:

```json
{"id":"apple_watch","name":"Apple Watch","rssi@1m":-42}
```

2. Note how the reports for `espresense/devices/apple_watch/NODE` contain the **correct** rssi@1m value.

3. Reboot the node.

4. Observe that the reports now use the **incorrect** fallback value.