### PR TITLE
Update BH1750 sensor interval

### DIFF
--- a/src/BH1750.cpp
+++ b/src/BH1750.cpp
@@ -17,7 +17,7 @@ namespace BH1750
     String BH1750_I2c;
     int BH1750_I2c_Bus;
     bool initialized = false;
-    int sensorInterval = 60000;
+    int sensorInterval = 5000;
 
     void Setup()
     {


### PR DESCRIPTION
Decreased sensor interval from 60 sec to 2 sec, for rapid sensor readings.
This helps a lot in a plethora of light-related automations based on this value. This was also mentioned in #744.