### PR TITLE
Add missing return in BleFingerprint::fingerprintServiceAdvertisements / Fix incorrect check in hextostr()

### DIFF
--- a/lib/BleFingerprint/BleFingerprint.cpp
+++ b/lib/BleFingerprint/BleFingerprint.cpp
@@ -236,6 +236,7 @@ void BleFingerprint::fingerprintServiceAdvertisements(NimBLEAdvertisedDevice *ad
         } else if (uuid == miFloraUUID) {
             asRssi = BleFingerprintCollection::rxRefRssi + (haveTxPower ? txPower : FLORA_TX);
             setId("flora:" + getMac(), ID_TYPE_FLORA);
+            return;
         }
     }
 

--- a/lib/BleFingerprint/string_utils.cpp
+++ b/lib/BleFingerprint/string_utils.cpp
@@ -107,7 +107,7 @@ uint8_t hextob(char ch)
 
 bool hextostr(const String &hexStr, uint8_t* output, size_t len)
 {
-    if (len & 1) return false;
+    if (hexStr.length() & 1) return false;
     if (hexStr.length() < len*2) return false;
     int k = 0;
     for (size_t i = 0; i < len*2; i+=2)


### PR DESCRIPTION
**Add missing return in BleFingerprint::fingerprintServiceAdvertisements**

This isn't _strictly_ required because `setId()` ignores "downgrades" to more generic ID types (i.e. from `ID_TYPE_FLORA` to `ID_TYPE_AD` in this case) but skips running unnecessary code and makes the code more readable.

**Fix incorrect check in hextostr()**

This function decodes hex-encoded strings (e.g. "41" -> "A"). Previously we'd check whether the output buffer's size is a multiple of two. This would incorrectly reject valid uses of the function. Instead we should check the input string's length.