### PR TITLE
Copy all statistics values when a device's MAC address changes

### DIFF
--- a/lib/BleFingerprint/BleFingerprint.cpp
+++ b/lib/BleFingerprint/BleFingerprint.cpp
@@ -449,10 +449,16 @@ bool BleFingerprint::seen(BLEAdvertisedDevice *advertisedDevice) {
     return false;
 }
 
-void BleFingerprint::setInitial(int initalRssi, float initalDistance) {
-    newest = recent = oldest = rssi = initalRssi;
-    raw = initalDistance;
-    hasValue = filter() || filter();
+void BleFingerprint::setInitial(const BleFingerprint &other) {
+    newest = other.newest;
+    recent = other.recent;
+    oldest = other.oldest;
+    rssi = other.rssi;
+    raw = other.rssi;
+    output = other.output;
+    oneEuro = other.oneEuro;
+    diffFilter = other.diffFilter;
+    hasValue = other.hasValue;
 }
 
 void BleFingerprint::fill(JsonObject *doc) {

--- a/lib/BleFingerprint/BleFingerprint.h
+++ b/lib/BleFingerprint/BleFingerprint.h
@@ -80,7 +80,7 @@ class BleFingerprint {
 
     bool setId(const String &newId, short int newIdType, const String &newName = "");
 
-    void setInitial(int rssi, float distance);
+    void setInitial(const BleFingerprint &other);
 
     const String getMac() const;
 

--- a/lib/BleFingerprint/BleFingerprintCollection.cpp
+++ b/lib/BleFingerprint/BleFingerprintCollection.cpp
@@ -201,7 +201,7 @@ BleFingerprint *getFingerprintInternal(BLEAdvertisedDevice *advertisedDevice) {
     if (it2 != fingerprints.end()) {
         auto found = *it2;
         // Serial.printf("Detected mac switch for fingerprint id %s\r\n", found->getId().c_str());
-        created->setInitial(found->getRssi(), found->getDistance());
+        created->setInitial(*found);
         if (found->getIdType() > ID_TYPE_UNIQUE)
             found->expire();
     }


### PR DESCRIPTION
When a device's MAC address changes we attempt to keep old distance measurements. This can be improved by also copying the filter state and a few more related values.

Here's an example where the old mechanism leads to a random spike for the distance measurement:

<img width="327" alt="Screenshot 2023-11-08 at 19 16 46" src="https://github.com/ESPresense/ESPresense/assets/388571/9395c73c-f54b-4cee-b54a-e14608db5c5c">
