### PR TITLE
Add build timestamp to the version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ CMakeLists.txt
 CMakeListsPrivate.txt
 platformio_override.ini
 node_modules
+src/build_timestamp_value.h

--- a/platformio.ini
+++ b/platformio.ini
@@ -61,6 +61,7 @@ board_build.partitions = partitions_singleapp.csv
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder, time
 upload_speed = 1500000
+extra_scripts = update_ts.py
 
 [esp32]
 extends = common

--- a/src/build_timestamp.cpp
+++ b/src/build_timestamp.cpp
@@ -1,0 +1,6 @@
+#include "build_timestamp.h"
+#include "build_timestamp_value.h"
+
+const char *getBuildTimestamp() {
+    return BUILD_TIMESTAMP;
+}

--- a/src/build_timestamp.h
+++ b/src/build_timestamp.h
@@ -1,0 +1,1 @@
+const char *getBuildTimestamp();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,7 +91,7 @@ bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned in
 #ifdef VERSION
     doc["ver"] = String(VERSION);
 #else
-    doc["ver"] = ESP.getSketchMD5();
+    doc["ver"] = ESP.getSketchMD5() + "-" + getBuildTimestamp();
 #endif
 
     if (!BleFingerprintCollection::countIds.isEmpty())

--- a/src/main.h
+++ b/src/main.h
@@ -27,6 +27,7 @@
 #include "globals.h"
 #include "mqtt.h"
 #include "string_utils.h"
+#include "build_timestamp.h"
 #ifdef M5STICK
 #include <AXP192.h>
 #endif

--- a/update_ts.py
+++ b/update_ts.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from datetime import datetime
+
+with open("src/build_timestamp_value.h", "w") as fp:
+    timestamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    fp.write(f'#define BUILD_TIMESTAMP "{timestamp}"')


### PR DESCRIPTION
I've found this rather useful when repeatedly deploying updated firmware images to a large number of nodes.

The patch carefully avoids full rebuilds of any "real" source files by putting the timestamp into a separate .cpp file. It also works around PlatformIO's build cache that would happily permanently cache the timestamp file if we were using `__DATE__`.

The Python script isn't entirely necessary because we could just simply `touch` the timestamp file via `extra_scripts` to force a rebuild. But we'd need _some_ kind of script anyway and this way we can format the timestamp more easily than is possible with C++.

<img width="892" alt="Screenshot 2023-12-02 at 22 19 53" src="https://github.com/ESPresense/ESPresense/assets/388571/10e9e6c0-545d-42b3-b404-87c7272627dd">
