### PR TITLE
Add https:// -> wss:// replace call

### DIFF
--- a/ui/src/stores.js
+++ b/ui/src/stores.js
@@ -66,7 +66,7 @@ export const devices = readable([], function start(set) {
 var initialValue = {};
 var socket = null;
 export const events = readable(initialValue, function start(set) {
-    socket = new WebSocket(`${location.origin.replace('http://', 'ws://')}/ws`);
+    socket = new WebSocket(`${location.origin.replace('http://', 'ws://').replace('https://', 'wss://')}/ws`);
     socket.addEventListener('message', function (event) {
         initialValue = JSON.parse(event.data);
         console.log("Receive: " + event.data);


### PR DESCRIPTION
I use a reverse proxy for tls & proxying traffic to my espresense nodes. The config & ui pages work fine, but the websocket connection fails on the devices page here:

```
new WebSocket(`${location.origin.replace("http://", "ws://")}/ws`))
```

Since my `window.location.origin` starts with `https://`, the replace doesn't happen. I need `wss://` instead of `ws://`. 

This is the error I see in the browser console:
```
index.js:1  Uncaught (in promise) DOMException: Failed to construct 'WebSocket': The URL's scheme must be either 'ws' or 'wss'. 'https' is not allowed.
    at https://espr1.myhouse.com/ui/index.js:1:22244
    at Object.subscribe (https://espr1.myhouse.com/ui/index.js:1:6827)
    at o (https://espr1.myhouse.com/ui/index.js:1:393)
    at i (https://espr1.myhouse.com/ui/index.js:1:491)
    at zt (https://espr1.myhouse.com/ui/index.js:1:50277)
    at _e (https://espr1.myhouse.com/ui/index.js:1:5493)
    at new /devices (https://espr1.myhouse.com/ui/index.js:1:108185)
    at A (https://espr1.myhouse.com/ui/index.js:1:2750)
    at Object.p (https://espr1.myhouse.com/ui/index.js:1:8113)
    at Object.p (https://espr1.myhouse.com/ui/index.js:1:9277)
```

The only workaround besides a code change here is to try and rewrite the content being sent back to the browser before it's sent back by the proxy, but I haven't had any luck with it (espresence.yaml traefik 3 config below if you're curious).

```
http:
  routers:
    espr1-web:
      rule: Host(`espr1.myhouse.com`)
      service: espr1-web-svc
      entrypoints: websecure
      middlewares:
        - no-compression
        - rewrite-javascript

  middlewares:
    no-compression:
      headers:
        customRequestHeaders:
          # Prevent gzip, brotli
          Accept-Encoding: "identity"
    rewrite-javascript:
      plugin:
        rewrite-body:
          lastModified: true
          rewrites:
            regex: '(http|ws):'
            replacement: '${1}s:'
          monitoring:
            types:
              - text/html
              - text/json
              - application/json
              - application/javascript

  services:
    espr1-web-svc:
      loadBalancer:
        servers:
          - url: http://10.2.250.1
```