### PR TITLE
Sensor DS18B20  Check to Skip Null Values

### DIFF
--- a/src/DS18B20.cpp
+++ b/src/DS18B20.cpp
@@ -130,8 +130,10 @@ namespace DS18B20
             for (int i = 0; i < numSensors; i++){
                 float temperature = sensors.getTempCByIndex(i) + dsTempOffset;
                 Serial.println("DS18B20 Temp_"+ String(i+1) + ": " + String(temperature, 1) + "'C");
-
-                pub((roomsTopic + "/ds18b20_temperature_" + String(i+1)).c_str(), 0, 1, String(temperature, 1).c_str());
+                if( sensors.getTempCByIndex(i) > -127) // Skip null values
+                {
+                    pub((roomsTopic + "/ds18b20_temperature_" + String(i+1)).c_str(), 0, 1, String(temperature, 1).c_str());
+                }
             }
 
             gotNewTemperature = false;


### PR DESCRIPTION
I have 1 device that occasionally has the DS18B20 sensor give a bad value of -127. A second device with 8 sensors is giving me this bad sensor value every few minutes. Likely do to poor build quality on my part. 
![Pasted image 20231218115740](https://github.com/ESPresense/ESPresense/assets/779440/a8ae5a09-08d9-41ea-a240-f7f9b5b95ed8)

This fix checks for that low, invalid value of -127 and skips the data publish.