### PR TITLE
Add M5Stack ENV IV Sensor

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -129,6 +129,7 @@ lib_deps =
   sensirion/arduino-sht@^1.2.2
   paulstoffregen/OneWire@^2.3.7
   milesburton/DallasTemperature@^3.11.0
+  m5stack/M5Unit-ENV@^1.0.1
 
 [env:esp32]
 extends = esp32

--- a/src/ENVIV.cpp
+++ b/src/ENVIV.cpp
@@ -91,8 +91,8 @@ namespace ENVIV
     {
         //Serial.println("env IV send discovery");
         //if (BMP280_I2c.isEmpty()) return true;
-        return sendSensorDiscovery("ENV IV Temperature", EC_NONE, "temperature", "°C")
-            && sendSensorDiscovery("ENV IV Pressure", EC_NONE, "pressure", "hPa")
+        return sendSensorDiscovery("ENVIV Temperature", EC_NONE, "temperature", "°C")
+            && sendSensorDiscovery("ENVIV Pressure", EC_NONE, "pressure", "hPa")
             && sendSensorDiscovery("SHT40 Temperature", EC_NONE, "temperature", "°C")
             && sendSensorDiscovery("SHT40 Humidity", EC_NONE, "humidity", "%");
     }

--- a/src/ENVIV.cpp
+++ b/src/ENVIV.cpp
@@ -65,16 +65,6 @@ namespace ENVIV
         Serial.println(BMP280_I2c + " on bus " + BMP280_I2c_Bus);
     }
 
-    bool SendDiscovery()
-    {
-        //Serial.println("env IV send discovery");
-        //if (BMP280_I2c.isEmpty()) return true;
-        return sendSensorDiscovery("ENV IV Temperature", EC_NONE, "temperature", "°C")
-            && sendSensorDiscovery("ENV IV Pressure", EC_NONE, "pressure", "hPa")
-            && sendSensorDiscovery("SHT40 Temperature", EC_NONE, "temperature", "°C")
-            && sendSensorDiscovery("SHT40 Humidity", EC_NONE, "humidity", "%");
-    }
-
     void Loop()
     {
         if (!I2C_Bus_1_Started && !I2C_Bus_2_Started) return;
@@ -96,6 +86,17 @@ namespace ENVIV
             BMP280PreviousMillis = millis();
         }
     }
+    
+    bool SendDiscovery()
+    {
+        //Serial.println("env IV send discovery");
+        //if (BMP280_I2c.isEmpty()) return true;
+        return sendSensorDiscovery("ENV IV Temperature", EC_NONE, "temperature", "°C")
+            && sendSensorDiscovery("ENV IV Pressure", EC_NONE, "pressure", "hPa")
+            && sendSensorDiscovery("SHT40 Temperature", EC_NONE, "temperature", "°C")
+            && sendSensorDiscovery("SHT40 Humidity", EC_NONE, "humidity", "%");
+    }
+
 }
 
 #endif

--- a/src/ENVIV.cpp
+++ b/src/ENVIV.cpp
@@ -13,8 +13,8 @@ namespace ENVIV
     BMP280 bmp;
     SHT4X sht;
     //long BMP280_status;
-    String BMP280_I2c;
-    int BMP280_I2c_Bus;  
+    String ENVIVBMP280_I2c;
+    int ENVIVBMP280_I2c_Bus;  
     unsigned long BMP280PreviousMillis = 0;
     int sensorInterval = 60000;
     bool initialized = false;
@@ -53,8 +53,8 @@ namespace ENVIV
     void ConnectToWifi()
     {
         //Serial.println("env IV connect to wifi");
-        BMP280_I2c_Bus = AsyncWiFiSettings.integer("BMP280_I2c_Bus", 1, 2, DEFAULT_I2C_BUS, "I2C Bus");
-        BMP280_I2c = AsyncWiFiSettings.string("BMP280_I2c", "", "I2C address (0x76 or 0x77)");
+        ENVIVBMP280_I2c_Bus = AsyncWiFiSettings.integer("ENVIVBMP280_I2c_Bus", 1, 2, DEFAULT_I2C_BUS, "I2C Bus");
+        ENVIVBMP280_I2c = AsyncWiFiSettings.string("ENVIVBMP280_I2c", "", "I2C address (0x76 or 0x77)");
     }
 
     void SerialReport()
@@ -62,13 +62,14 @@ namespace ENVIV
         if (!I2C_Bus_1_Started && !I2C_Bus_2_Started) return;
         //if (BMP280m5_I2c.isEmpty()) return;
         Serial.print("ENVIV BMP280:       ");
-        Serial.println(BMP280_I2c + " on bus " + BMP280_I2c_Bus);
+        Serial.println(ENVIVBMP280_I2c + " on bus " + ENVIVBMP280_I2c_Bus);
     }
 
     void Loop()
     {
         if (!I2C_Bus_1_Started && !I2C_Bus_2_Started) return;
         if (!initialized) return;
+        if (!initializedsht) return;
 
         if (BMP280PreviousMillis == 0 || millis() - BMP280PreviousMillis >= sensorInterval) {
 
@@ -90,7 +91,7 @@ namespace ENVIV
     bool SendDiscovery()
     {
         //Serial.println("env IV send discovery");
-        //if (BMP280_I2c.isEmpty()) return true;
+        if (ENVIVBMP280_I2c.isEmpty()) return true;
         return sendSensorDiscovery("ENVIV Temperature", EC_NONE, "temperature", "°C")
             && sendSensorDiscovery("ENVIV Pressure", EC_NONE, "pressure", "hPa")
             && sendSensorDiscovery("SHT40 Temperature", EC_NONE, "temperature", "°C")

--- a/src/ENVIV.cpp
+++ b/src/ENVIV.cpp
@@ -7,6 +7,7 @@
 #include "string_utils.h"
 
 #include <M5UnitENV.h>
+#include <SHT4x.h>
 
 namespace ENVIV
 {

--- a/src/ENVIV.cpp
+++ b/src/ENVIV.cpp
@@ -69,8 +69,10 @@ namespace ENVIV
     {
         //Serial.println("env IV send discovery");
         //if (BMP280_I2c.isEmpty()) return true;
-        return sendSensorDiscovery("enviv_temperature", EC_NONE, "temperature", "°C")
-            && sendSensorDiscovery("enviv_pressure", EC_NONE, "pressure", "hPa");
+        return sendSensorDiscovery("ENV IV Temperature", EC_NONE, "temperature", "°C")
+            && sendSensorDiscovery("ENV IV Pressure", EC_NONE, "pressure", "hPa")
+            && sendSensorDiscovery("SHT40 Temperature", EC_NONE, "temperature", "°C")
+            && sendSensorDiscovery("SHT40 Humidity", EC_NONE, "humidity", "%");
     }
 
     void Loop()
@@ -83,10 +85,14 @@ namespace ENVIV
             bmp.takeForcedMeasurement();
             bmp.readTemperature();
             bmp.readPressure(); 
-        
+
+            sht.update();
+
             pub((roomsTopic + "/enviv_temperature").c_str(), 0, true, String(bmp.cTemp).c_str());
             pub((roomsTopic + "/enviv_pressure").c_str(), 0, true, String(bmp.pressure / 100).c_str());
-
+            pub((roomsTopic + "/sht40_temperature").c_str(), 0, true, String(sht.cTemp).c_str());
+            pub((roomsTopic + "/sht40_humidity").c_str(), 0, true, String(sht.humidity).c_str());
+            
             BMP280PreviousMillis = millis();
         }
     }

--- a/src/ENVIV.cpp
+++ b/src/ENVIV.cpp
@@ -7,17 +7,18 @@
 #include "string_utils.h"
 
 #include <M5UnitENV.h>
-#include <SHT4x.h>
 
 namespace ENVIV
 {
     BMP280 bmp;
+    SHT4X sht;
     //long BMP280_status;
     String BMP280_I2c;
     int BMP280_I2c_Bus;  
     unsigned long BMP280PreviousMillis = 0;
     int sensorInterval = 60000;
     bool initialized = false;
+    bool initializedsht = false;
     
     void Setup() {
         //Serial.println("starting env IV setup");
@@ -37,6 +38,16 @@ namespace ENVIV
                         BMP280::SAMPLING_X16,    /* Pressure oversampling */
                         BMP280::FILTER_X16,      /* Filtering. */
                         BMP280::STANDBY_MS_500); /* Standby time. */
+
+        if (!sht.begin(&Wire, SHT40_I2C_ADDR_44, 2, 1, 400000U)) {
+            Serial.println("[ENVIV SHT40]  Couldn't find SHT40, check your wiring and I2C address!");
+            while (1) delay(1);
+        } else {
+            initializedsht = true;
+        }
+
+        sht.setPrecision(SHT4X_HIGH_PRECISION);
+        sht.setHeater(SHT4X_NO_HEATER);
     }
 
     void ConnectToWifi()

--- a/src/ENVIV.cpp
+++ b/src/ENVIV.cpp
@@ -1,0 +1,83 @@
+#ifdef SENSORS
+#include "ENVIV.h"
+#include "globals.h"
+#include "mqtt.h"
+#include "defaults.h"
+#include <AsyncWiFiSettings.h>
+#include "string_utils.h"
+
+#include <M5UnitENV.h>
+
+namespace ENVIV
+{
+    BMP280 bmp;
+    //long BMP280_status;
+    String BMP280_I2c;
+    int BMP280_I2c_Bus;  
+    unsigned long BMP280PreviousMillis = 0;
+    int sensorInterval = 60000;
+    bool initialized = false;
+    
+    void Setup() {
+        //Serial.println("starting env IV setup");
+        if (!I2C_Bus_1_Started && !I2C_Bus_2_Started) return;
+        //Serial.println("bus check complete");
+
+        if (!bmp.begin(&Wire, BMP280_I2C_ADDR, 2, 1, 400000U)) {
+            Serial.println("[ENVIV BMP280] Couldn't find a sensor, check your wiring and I2C address!");
+            while (1) delay(1);
+        } else {
+            initialized = true;
+        }
+
+        /* Default settings from datasheet. */
+        bmp.setSampling(BMP280::MODE_NORMAL,     /* Operating Mode. */
+                        BMP280::SAMPLING_X2,     /* Temp. oversampling */
+                        BMP280::SAMPLING_X16,    /* Pressure oversampling */
+                        BMP280::FILTER_X16,      /* Filtering. */
+                        BMP280::STANDBY_MS_500); /* Standby time. */
+    }
+
+    void ConnectToWifi()
+    {
+        //Serial.println("env IV connect to wifi");
+        BMP280_I2c_Bus = AsyncWiFiSettings.integer("BMP280_I2c_Bus", 1, 2, DEFAULT_I2C_BUS, "I2C Bus");
+        BMP280_I2c = AsyncWiFiSettings.string("BMP280_I2c", "", "I2C address (0x76 or 0x77)");
+    }
+
+    void SerialReport()
+    {
+        if (!I2C_Bus_1_Started && !I2C_Bus_2_Started) return;
+        //if (BMP280m5_I2c.isEmpty()) return;
+        Serial.print("ENVIV BMP280:       ");
+        Serial.println(BMP280_I2c + " on bus " + BMP280_I2c_Bus);
+    }
+
+    bool SendDiscovery()
+    {
+        //Serial.println("env IV send discovery");
+        //if (BMP280_I2c.isEmpty()) return true;
+        return sendSensorDiscovery("enviv_temperature", EC_NONE, "temperature", "°C")
+            && sendSensorDiscovery("enviv_pressure", EC_NONE, "pressure", "hPa");
+    }
+
+    void Loop()
+    {
+        if (!I2C_Bus_1_Started && !I2C_Bus_2_Started) return;
+        if (!initialized) return;
+
+        if (BMP280PreviousMillis == 0 || millis() - BMP280PreviousMillis >= sensorInterval) {
+
+            bmp.takeForcedMeasurement();
+            bmp.readTemperature();
+            bmp.readPressure(); 
+        
+            pub((roomsTopic + "/enviv_temperature").c_str(), 0, true, String(bmp.cTemp).c_str());
+            pub((roomsTopic + "/enviv_pressure").c_str(), 0, true, String(bmp.pressure / 100).c_str());
+
+            BMP280PreviousMillis = millis();
+        }
+    }
+}
+
+#endif

--- a/src/ENVIV.h
+++ b/src/ENVIV.h
@@ -1,0 +1,14 @@
+#pragma once
+#ifdef SENSORS
+#include <ArduinoJson.h>
+
+namespace ENVIV
+{
+    void ConnectToWifi();
+    void SerialReport();
+    bool SendDiscovery();
+    void Setup();
+    void Loop();
+}
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,7 @@ bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned in
             && SensirionSGP30::SendDiscovery()
             && HX711::SendDiscovery()
             && DS18B20::SendDiscovery()
+            && ENVIV::SendDiscovery()
 #endif
         ) {
             sentDiscovery = true;
@@ -203,6 +204,7 @@ void setupNetwork() {
     SensirionSGP30::ConnectToWifi();
     HX711::ConnectToWifi();
     DS18B20::ConnectToWifi();
+    ENVIV::ConnectToWifi();
 #endif
 
     unsigned int connectProgress = 0;
@@ -265,6 +267,7 @@ void setupNetwork() {
     SensirionSGP30::SerialReport();
     HX711::SerialReport();
     DS18B20::SerialReport();
+    ENVIV::SerialReport();
 
 #endif
     Serial.print("Query:        ");
@@ -567,6 +570,7 @@ void setup() {
     SensirionSGP30::Setup();
     HX711::Setup();
     DS18B20::Setup();
+    ENVIV::Setup();
 #endif
     xTaskCreatePinnedToCore(scanTask, "scanTask", SCAN_TASK_STACK_SIZE, nullptr, 1, &scanTaskHandle, CONFIG_BT_NIMBLE_PINNED_TO_CORE);
     reportSetup();
@@ -604,5 +608,6 @@ void loop() {
     SensirionSGP30::Loop();
     HX711::Loop();
     DS18B20::Loop();
+    ENVIV::Loop();
 #endif
 }

--- a/src/main.h
+++ b/src/main.h
@@ -46,6 +46,7 @@
 #include "SensirionSGP30.h"
 #include "TSL2561.h"
 #include "DS18B20.h"
+#include "ENVIV.h"
 #endif
 
 TimerHandle_t reconnectTimer;

--- a/ui/src/routes/Settings.svelte
+++ b/ui/src/routes/Settings.svelte
@@ -134,6 +134,9 @@
         <h4>DS18B20:</h4>
         <p><label>DS18B20 sensor pin (-1 for disable):<br /><input type="number" step="1" name="ds18b20_pin" placeholder="-1" bind:value={$extras.ds18b20_pin}/></label></p>
         <p><label>DS18B20 temperature offset:<br /><input type="number" step="0.01" min="-40" max="125" name="dsTemp_offset" placeholder="0.00" bind:value={$extras.dsTemp_offset}/></label></p>
+        <h4>ENVIV - Barometric Pressure + Temperature Sensor:</h4>
+        <p><label>I2C Bus:<br /><input type="number" step="1" min="1" max="2" name="ENVIVBMP280_I2c_Bus" placeholder="1" bind:value={$extras.ENVIVBMP280_I2c_Bus}/></label></p>
+        <p><label>I2C address (0x76 or 0x77):<br /><input name="ENVIVBMP280_I2c" bind:value={$extras.ENVIVBMP280_I2c}/></label></p>
         <div class="bc"><button class="btn left" on:click|preventDefault={restart}>{r ? "Restarting..." : "Restart"}</button><input class="btn right" type="submit" value={s ? "Saving..." : "Save"} /></div>
     </form>
     {/if}


### PR DESCRIPTION
As mentioned in https://github.com/ESPresense/ESPresense/issues/1385#issue-2546568653, this PR is to add the M5Stack ENV IV sensor to ESPresense.  

I could not get the Adafruit BMP280 library to work with the M5Stack device. I suspect there's something about the chip_id/chipid in the Adafruit library or the way the serial communications work on the M5Stack chip that just aren't playing well. So inside the ENV IV driver I included a new library from M5Stack that allows the BMP280 to communicate. Also, I couldn't get the SHT40 to work in concert with the BMP280 using the existing SHT driver. So I had to include the ENV IV SHT4X driver from M5Stack.

I have a one issue though that I can't seem to figure out is how to rebuild the UI to add these sensors.  Any help would be appreciated.

I have created a beta release and uploaded the build via the UI successfully and gotten both the BMP280 and SHT40 communicating using an M5Stack Atom S3 Lite on the S3 CDC and Standard builds before I changed the address names in the Serial Report, Connect to WiFi, and Discovery lines.  So I have NOT tested that portion and can't until the UI is rebuilt.