### PR TITLE
Added support for the `LilyGO-T-ETH-Lite` (`RTL8201` variant)

### DIFF
--- a/lib/network/Network.h
+++ b/lib/network/Network.h
@@ -35,7 +35,7 @@ public:
 #define CONFIG_ETH_LILYGO           8
 #define CONFIG_ETH_GLINET_S10_V21   9
 #define CONFIG_ETH_EST_POE_32       10
-#define CONFIG_ETH_LILYGO_LITE      11
+#define CONFIG_ETH_LILYGO_LITE_RTL  11
 
 // For ESP32, the remaining five pins are at least somewhat configurable.
 // eth_address  is in range [0..31], indicates which PHY (MAC?) address should be allocated to the interface

--- a/lib/network/Network.h
+++ b/lib/network/Network.h
@@ -22,7 +22,7 @@ public:
   bool connect(int ethernetType, int wait_seconds, const char *hostName);
 };
 
-#define CONFIG_NUM_ETH_TYPES        11
+#define CONFIG_NUM_ETH_TYPES        12
 
 #define CONFIG_ETH_NONE             0
 #define CONFIG_ETH_WT32_ETH01       1
@@ -35,6 +35,7 @@ public:
 #define CONFIG_ETH_LILYGO           8
 #define CONFIG_ETH_GLINET_S10_V21   9
 #define CONFIG_ETH_EST_POE_32       10
+#define CONFIG_ETH_LILYGO_LITE      11
 
 // For ESP32, the remaining five pins are at least somewhat configurable.
 // eth_address  is in range [0..31], indicates which PHY (MAC?) address should be allocated to the interface
@@ -160,6 +161,16 @@ const ethernet_settings ethernetBoards[] = {
     18,                  // eth_mdio,
     ETH_PHY_LAN8720,     // eth_type,
     ETH_CLOCK_GPIO17_OUT // eth_clk_mode
+  },
+
+  // LilyGO-T-ETH-Lite
+  {
+    0,                    // eth_address,
+    12,                   // eth_power,
+    23,                   // eth_mdc,
+    18,                   // eth_mdio,
+    ETH_PHY_RTL8201,      // eth_type,
+    ETH_CLOCK_GPIO0_IN    // eth_clk_mode
   }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,7 +138,7 @@ void setupNetwork() {
     room = AsyncWiFiSettings.string("room", ESPMAC, "Room");
     auto wifiTimeout = AsyncWiFiSettings.integer("wifi_timeout", DEFAULT_WIFI_TIMEOUT, "Seconds to wait for WiFi before captive portal (-1 = forever)");
     auto portalTimeout = 1000UL * AsyncWiFiSettings.integer("portal_timeout", DEFAULT_PORTAL_TIMEOUT, "Seconds to wait in captive portal before rebooting");
-    std::vector<String> ethernetTypes = {"None", "WT32-ETH01", "ESP32-POE", "WESP32", "QuinLED-ESP32", "TwilightLord-ESP32", "ESP32Deux", "KIT-VE", "LilyGO-T-ETH-POE", "GL-inet GL-S10 v2.1 Ethernet", "EST-PoE-32"};
+    std::vector<String> ethernetTypes = {"None", "WT32-ETH01", "ESP32-POE", "WESP32", "QuinLED-ESP32", "TwilightLord-ESP32", "ESP32Deux", "KIT-VE", "LilyGO-T-ETH-POE", "GL-inet GL-S10 v2.1 Ethernet", "EST-PoE-32", "LilyGO-T-ETH-Lite"};
     ethernetType = AsyncWiFiSettings.dropdown("eth", ethernetTypes, 0, "Ethernet Type");
 
     AsyncWiFiSettings.heading("<a href='https://espresense.com/configuration/settings#mqtt' target='_blank'>MQTT</a>", false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,7 +138,7 @@ void setupNetwork() {
     room = AsyncWiFiSettings.string("room", ESPMAC, "Room");
     auto wifiTimeout = AsyncWiFiSettings.integer("wifi_timeout", DEFAULT_WIFI_TIMEOUT, "Seconds to wait for WiFi before captive portal (-1 = forever)");
     auto portalTimeout = 1000UL * AsyncWiFiSettings.integer("portal_timeout", DEFAULT_PORTAL_TIMEOUT, "Seconds to wait in captive portal before rebooting");
-    std::vector<String> ethernetTypes = {"None", "WT32-ETH01", "ESP32-POE", "WESP32", "QuinLED-ESP32", "TwilightLord-ESP32", "ESP32Deux", "KIT-VE", "LilyGO-T-ETH-POE", "GL-inet GL-S10 v2.1 Ethernet", "EST-PoE-32", "LilyGO-T-ETH-Lite"};
+    std::vector<String> ethernetTypes = {"None", "WT32-ETH01", "ESP32-POE", "WESP32", "QuinLED-ESP32", "TwilightLord-ESP32", "ESP32Deux", "KIT-VE", "LilyGO-T-ETH-POE", "GL-inet GL-S10 v2.1 Ethernet", "EST-PoE-32", "LilyGO-T-ETH-Lite (RTL8201)"};
     ethernetType = AsyncWiFiSettings.dropdown("eth", ethernetTypes, 0, "Ethernet Type");
 
     AsyncWiFiSettings.heading("<a href='https://espresense.com/configuration/settings#mqtt' target='_blank'>MQTT</a>", false);


### PR DESCRIPTION
Added support for the `RTL8201` NIC found on LilyGO's `T-ETH-Lite`

Tested it on my T-ETH-Lite (with & without the POE)

https://lilygo.cc/products/t-eth-lite?variant=43120880746677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for LilyGO-T-ETH-Lite Ethernet device
	- Expanded Ethernet configuration options with a new hardware variant

- **Chores**
	- Updated Ethernet type configuration to include the new device

<!-- end of auto-generated comment: release notes by coderabbit.ai -->