### PR TITLE
Remove publish rooms in v4

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,7 +147,6 @@ void setupNetwork() {
     discovery = HeadlessWiFiSettings.checkbox("discovery", true, "Send to discovery topic");
     homeAssistantDiscoveryPrefix = HeadlessWiFiSettings.string("discovery_prefix", DEFAULT_HA_DISCOVERY_PREFIX, "Home Assistant discovery topic prefix");
     publishTele = HeadlessWiFiSettings.checkbox("pub_tele", true, "Send to telemetry topic");
-    publishRooms = HeadlessWiFiSettings.checkbox("pub_rooms_dep", false, "Send to rooms topic (deprecated in v4)");
     publishDevices = HeadlessWiFiSettings.checkbox("pub_devices", true, "Send to devices topic");
 
     Updater::ConnectToWifi();
@@ -388,17 +387,9 @@ bool reportDevice(BleFingerprint *f) {
     serializeJson(doc, buffer);
     String devicesTopic = Sprintf(CHANNEL "/devices/%s/%s", f->getId().c_str(), id.c_str());
 
-    bool p1 = false, p2 = false;
     for (int i = 0; i < 10; i++) {
         if (!mqttClient.connected()) return false;
-        if (!p1 && (!publishRooms || mqttClient.publish(roomsTopic.c_str(), 0, false, buffer.c_str())))
-            p1 = true;
-
-        if (!p2 && (!publishDevices || mqttClient.publish(devicesTopic.c_str(), 0, false, buffer.c_str())))
-            p2 = true;
-
-        if (p1 && p2)
-            return true;
+        if (!publishDevices || mqttClient.publish(devicesTopic.c_str(), 0, false, buffer.c_str())) return true;
         delay(20);
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -64,4 +64,4 @@ int ethernetType = 0;
 String mqttHost, mqttUser, mqttPass;
 uint16_t mqttPort;
 
-bool discovery, publishTele, publishRooms, publishDevices;
+bool discovery, publishTele, publishDevices;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed an outdated network configuration option, eliminating the redundant control related to room-specific data.
	- Streamlined data publishing by focusing solely on device-related information for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->