### PR TITLE
Set default absorption to 3 (was 3.5)

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -56,7 +56,7 @@
 
 #define DEFAULT_RX_REF_RSSI (-65)
 #define DEFAULT_TX_REF_RSSI (-59)
-#define DEFAULT_ABSORPTION (3.5)
+#define DEFAULT_ABSORPTION (3.0)
 #define DEFAULT_RX_ADJ_RSSI 0
 
 #define DEFAULT_FORGET_MS 150000 // Ms to remove fingerprint after not seeing it


### PR DESCRIPTION
This is a more reasonable value (still conservative) for a default path loss exponent.  And since we're doing a breaking change, this is the time to change it.