### PR TITLE
V4 *breaking* set default absorption (path loss exponent) to 2.7

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -56,7 +56,7 @@
 
 #define DEFAULT_RX_REF_RSSI (-65)
 #define DEFAULT_TX_REF_RSSI (-59)
-#define DEFAULT_ABSORPTION (3.5)
+#define DEFAULT_ABSORPTION (2.7)
 #define DEFAULT_RX_ADJ_RSSI 0
 
 #define DEFAULT_FORGET_MS 150000 // Ms to remove fingerprint after not seeing it


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted an internal absorption parameter from 3.5 to 2.7 to optimize related calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->