### PR TITLE
DS18B20: always request temperatures on initialization

### DIFF
--- a/src/DS18B20.cpp
+++ b/src/DS18B20.cpp
@@ -54,6 +54,7 @@ namespace DS18B20
         {
             // avoid 85 C readings on initialization
             if (!initialReadDone) {
+                sensors.requestTemperatures();
                 delay(dsFirstReadDelayS * 1000);
                 bool allReadsOk = true;
                 for (int i = 0; i < numSensors; i++) {


### PR DESCRIPTION
Add `sensors.requestTemperatures()` call on first read.

Amazingly, it looks like it *sometimes* works without requesting temperatures, but let's make sure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of initial temperature readings by adjusting the sensor query timing immediately after startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->