### PR TITLE
Add support for ESP32-POE A1 variant with eth_address 1

### DIFF
--- a/lib/network/Network.h
+++ b/lib/network/Network.h
@@ -22,7 +22,7 @@ public:
   bool connect(int ethernetType, int wait_seconds, const char *hostName);
 };
 
-#define CONFIG_NUM_ETH_TYPES        12
+#define CONFIG_NUM_ETH_TYPES        13
 
 #define CONFIG_ETH_NONE             0
 #define CONFIG_ETH_WT32_ETH01       1
@@ -36,6 +36,7 @@ public:
 #define CONFIG_ETH_GLINET_S10_V21   9
 #define CONFIG_ETH_EST_POE_32       10
 #define CONFIG_ETH_LILYGO_LITE_RTL  11
+#define CONFIG_ETH_ESP32_POE_A1     12
 
 // For ESP32, the remaining five pins are at least somewhat configurable.
 // eth_address  is in range [0..31], indicates which PHY (MAC?) address should be allocated to the interface
@@ -81,16 +82,6 @@ const ethernet_settings ethernetBoards[] = {
     18,                  // eth_mdio,
     ETH_PHY_LAN8720,     // eth_type,
     ETH_CLOCK_GPIO17_OUT // eth_clk_mode
-  },
-
-  // ESP32-POE_A1
-  {
-    1,                  // eth_address,
-   12,                  // eth_power,
-   23,                  // eth_mdc,
-   18,                  // eth_mdio,
-   ETH_PHY_LAN8720,     // eth_type,
-   ETH_CLOCK_GPIO17_OUT // eth_clk_mode
   },
 
    // WESP32
@@ -181,6 +172,16 @@ const ethernet_settings ethernetBoards[] = {
     18,                   // eth_mdio,
     ETH_PHY_RTL8201,      // eth_type,
     ETH_CLOCK_GPIO0_IN    // eth_clk_mode
+  },
+
+  // ESP32-POE_A1
+  {
+    1,                  // eth_address,
+   12,                  // eth_power,
+   23,                  // eth_mdc,
+   18,                  // eth_mdio,
+   ETH_PHY_LAN8720,     // eth_type,
+   ETH_CLOCK_GPIO17_OUT // eth_clk_mode
   }
 };
 

--- a/lib/network/Network.h
+++ b/lib/network/Network.h
@@ -75,12 +75,22 @@ const ethernet_settings ethernetBoards[] = {
 
   // ESP32-POE
   {
-     1,                  // eth_address,
+    0,                  // eth_address,
     12,                  // eth_power,
     23,                  // eth_mdc,
     18,                  // eth_mdio,
     ETH_PHY_LAN8720,     // eth_type,
     ETH_CLOCK_GPIO17_OUT // eth_clk_mode
+  },
+
+  // ESP32-POE_A1
+  {
+    1,                  // eth_address,
+   12,                  // eth_power,
+   23,                  // eth_mdc,
+   18,                  // eth_mdio,
+   ETH_PHY_LAN8720,     // eth_type,
+   ETH_CLOCK_GPIO17_OUT // eth_clk_mode
   },
 
    // WESP32

--- a/lib/network/Network.h
+++ b/lib/network/Network.h
@@ -75,7 +75,7 @@ const ethernet_settings ethernetBoards[] = {
 
   // ESP32-POE
   {
-     0,                  // eth_address,
+     1,                  // eth_address,
     12,                  // eth_power,
     23,                  // eth_mdc,
     18,                  // eth_mdio,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,7 +137,7 @@ void setupNetwork() {
     HeadlessWiFiSettings.pstring("wifi-password", "", "WiFi Password");
     auto wifiTimeout = HeadlessWiFiSettings.integer("wifi_timeout", DEFAULT_WIFI_TIMEOUT, "Seconds to wait for WiFi before captive portal (-1 = forever)");
     auto portalTimeout = 1000UL * HeadlessWiFiSettings.integer("portal_timeout", DEFAULT_PORTAL_TIMEOUT, "Seconds to wait in captive portal before rebooting");
-    std::vector<String> ethernetTypes = {"None", "WT32-ETH01", "ESP32-POE", "WESP32", "QuinLED-ESP32", "TwilightLord-ESP32", "ESP32Deux", "KIT-VE", "LilyGO-T-ETH-POE", "GL-inet GL-S10 v2.1 Ethernet", "EST-PoE-32", "LilyGO-T-ETH-Lite (RTL8201)"};
+    std::vector<String> ethernetTypes = {"None", "WT32-ETH01", "ESP32-POE", "ESP32-POE_A1", "WESP32", "QuinLED-ESP32", "TwilightLord-ESP32", "ESP32Deux", "KIT-VE", "LilyGO-T-ETH-POE", "GL-inet GL-S10 v2.1 Ethernet", "EST-PoE-32", "LilyGO-T-ETH-Lite (RTL8201)"};
     ethernetType = HeadlessWiFiSettings.dropdown("eth", ethernetTypes, 0, "Ethernet Type");
 
     mqttHost = HeadlessWiFiSettings.string("mqtt_host", DEFAULT_MQTT_HOST, "Server");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,7 +137,7 @@ void setupNetwork() {
     HeadlessWiFiSettings.pstring("wifi-password", "", "WiFi Password");
     auto wifiTimeout = HeadlessWiFiSettings.integer("wifi_timeout", DEFAULT_WIFI_TIMEOUT, "Seconds to wait for WiFi before captive portal (-1 = forever)");
     auto portalTimeout = 1000UL * HeadlessWiFiSettings.integer("portal_timeout", DEFAULT_PORTAL_TIMEOUT, "Seconds to wait in captive portal before rebooting");
-    std::vector<String> ethernetTypes = {"None", "WT32-ETH01", "ESP32-POE", "ESP32-POE_A1", "WESP32", "QuinLED-ESP32", "TwilightLord-ESP32", "ESP32Deux", "KIT-VE", "LilyGO-T-ETH-POE", "GL-inet GL-S10 v2.1 Ethernet", "EST-PoE-32", "LilyGO-T-ETH-Lite (RTL8201)"};
+    std::vector<String> ethernetTypes = {"None", "WT32-ETH01", "ESP32-POE", "WESP32", "QuinLED-ESP32", "TwilightLord-ESP32", "ESP32Deux", "KIT-VE", "LilyGO-T-ETH-POE", "GL-inet GL-S10 v2.1 Ethernet", "EST-PoE-32", "LilyGO-T-ETH-Lite (RTL8201)", "ESP32-POE_A1"};
     ethernetType = HeadlessWiFiSettings.dropdown("eth", ethernetTypes, 0, "Ethernet Type");
 
     mqttHost = HeadlessWiFiSettings.string("mqtt_host", DEFAULT_MQTT_HOST, "Server");

--- a/ui/src/routes/network/+page.svelte
+++ b/ui/src/routes/network/+page.svelte
@@ -173,14 +173,15 @@
                     <option value="0">None</option>
                     <option value="1">WT32-ETH01</option>
                     <option value="2">ESP32-POE</option>
-                    <option value="3">WESP32</option>
-                    <option value="4">QuinLED-ESP32</option>
-                    <option value="5">TwilightLord-ESP32</option>
-                    <option value="6">ESP32Deux</option>
-                    <option value="7">KIT-VE</option>
-                    <option value="8">LilyGO-T-ETH-POE</option>
-                    <option value="9">GL-inet GL-S10 v2.1 Ethernet</option>
-                    <option value="10">EST-PoE-32</option>
+                    <option value="3">ESP32-POE_A1</option>
+                    <option value="4">WESP32</option>
+                    <option value="5">QuinLED-ESP32</option>
+                    <option value="6">TwilightLord-ESP32</option>
+                    <option value="7">ESP32Deux</option>
+                    <option value="8">KIT-VE</option>
+                    <option value="9">LilyGO-T-ETH-POE</option>
+                    <option value="10">GL-inet GL-S10 v2.1 Ethernet</option>
+                    <option value="11">EST-PoE-32</option>
                 </select>
             </div>
 

--- a/ui/src/routes/network/+page.svelte
+++ b/ui/src/routes/network/+page.svelte
@@ -173,15 +173,16 @@
                     <option value="0">None</option>
                     <option value="1">WT32-ETH01</option>
                     <option value="2">ESP32-POE</option>
-                    <option value="3">ESP32-POE_A1</option>
-                    <option value="4">WESP32</option>
-                    <option value="5">QuinLED-ESP32</option>
-                    <option value="6">TwilightLord-ESP32</option>
-                    <option value="7">ESP32Deux</option>
-                    <option value="8">KIT-VE</option>
-                    <option value="9">LilyGO-T-ETH-POE</option>
-                    <option value="10">GL-inet GL-S10 v2.1 Ethernet</option>
-                    <option value="11">EST-PoE-32</option>
+                    <option value="3">WESP32</option>
+                    <option value="4">QuinLED-ESP32</option>
+                    <option value="5">TwilightLord-ESP32</option>
+                    <option value="6">ESP32Deux</option>
+                    <option value="7">KIT-VE</option>
+                    <option value="8">LilyGO-T-ETH-POE</option>
+                    <option value="9">GL-inet GL-S10 v2.1 Ethernet</option>
+                    <option value="10">EST-PoE-32</option>
+                    <option value="11">LilyGO-T-ETH-Lite (RTL8201)</option>
+                    <option value="12">ESP32-POE_A1</option>
                 </select>
             </div>
 


### PR DESCRIPTION
## Intent

This PR adds a new Ethernet option for the ESP32-POE A1 variant.

Some newer ESP32-POE boards (specifically the A1 version) use eth_address = 1 instead of eth_address = 0, while keeping the rest of the Ethernet wiring identical to the original ESP32-POE layout.

Adding this option ensures proper compatibility with these newer boards without needing users to modify firmware manually.

Tested and verified with ESP32-POE A1 hardware.

## Validation

Flashed a version of firmware changing the native ESP32_PoE option to use A1 pin, worked well.

Weirdly I cant get the UI to update to validate this. I am not seeing the option in the Ethernet drop down. I assume I am not successfully rebuilding the frontend to fully test. Is there any way to fully test that and make sure the full stack builds properly? cc @DTTerastar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the "ESP32-POE_A1" Ethernet board.
  - Included "ESP32-POE_A1" as a selectable option in the Ethernet type dropdown menu.
  - Added "LilyGO-T-ETH-Lite (RTL8201)" as a new Ethernet type option in the network settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

