### PR TITLE
Fix extraSettings store initial value

### DIFF
--- a/ui/src/lib/stores.ts
+++ b/ui/src/lib/stores.ts
@@ -145,7 +145,7 @@ export function cancelEnroll(): void {
 
 export const mobileMenuOpen = writable<boolean>(false);
 
-export const extraSettings = writable<ExtraSettings | null>({}, function start(set) {
+export const extraSettings = writable<ExtraSettings | null>(null, function start(set) {
     fetch("/wifi/extras")
         .then(d => d.json())
         .then((r: ExtraSettings) => {


### PR DESCRIPTION
## Summary
- ensure the extraSettings store initializes to a null value

## Testing
- `npm run check` *(fails: svelte-kit not found)*
- `npm run build` *(fails: vite not found)*
- `pio run` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684816a916048324a0c6bd8285e4fbad