### PR TITLE
Add Playwright tests

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 
 .vite
 .svelte-kit
+test-results/

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@gfx/zopfli": "^1.0.15",
+        "@playwright/test": "^1.52.0",
         "@rollup/plugin-strip": "^3.0.4",
         "@sveltejs/adapter-static": "^3.0.8",
         "@sveltejs/kit": "^2.20.8",
@@ -585,6 +586,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -2217,6 +2234,53 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,10 +9,12 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "test": "playwright test"
   },
   "devDependencies": {
     "@gfx/zopfli": "^1.0.15",
+    "@playwright/test": "^1.52.0",
     "@rollup/plugin-strip": "^3.0.4",
     "@sveltejs/adapter-static": "^3.0.8",
     "@sveltejs/kit": "^2.20.8",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run dev -- --port 5173 --host 0.0.0.0',
+    port: 5173,
+    cwd: __dirname,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: { baseURL: 'http://localhost:5173' },
+});

--- a/ui/tests/basic.spec.ts
+++ b/ui/tests/basic.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test('network page loads', async ({ page }) => {
+  const response = await page.goto('/network');
+  expect(response?.ok()).toBeTruthy();
+  await expect(page.getByRole('heading', { name: /Room Configuration/i })).toBeVisible();
+});
+
+test('devices page loads', async ({ page }) => {
+  const response = await page.goto('/devices');
+  expect(response?.ok()).toBeTruthy();
+  await expect(page.getByRole('heading', { name: /Devices/i })).toBeVisible();
+});
+
+test('fingerprints page loads', async ({ page }) => {
+  const response = await page.goto('/fingerprints');
+  expect(response?.ok()).toBeTruthy();
+  await expect(page.getByRole('heading', { name: /Fingerprints/i })).toBeVisible();
+});
+
+test('settings page loads', async ({ page }) => {
+  const response = await page.goto('/settings');
+  expect(response?.ok()).toBeTruthy();
+  await expect(page.getByRole('heading', { name: /Scanning/i })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- install Playwright and add `test` script in `ui/package.json`
- configure Playwright to start the dev server
- create a minimal test verifying the network page is reachable
- expand Playwright tests to cover several UI pages

## Testing
- `npm test -- --workers=1 --reporter=list` *(fails: page navigation timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68480a8f5c3083249c5e7082b5f6c16e