### PR TITLE
Handle Dexcom fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,223 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.3.5]
+
+- See release notes on GitHub
+
+## [3.3.4]
+
+- See release notes on GitHub
+
+## [3.3.3]
+
+- See release notes on GitHub
+
+## [3.3.2]
+
+- See release notes on GitHub
+
+## [3.3.1]
+
+- See release notes on GitHub
+
+## [3.3.0]
+
+- See release notes on GitHub
+
+## [3.2.4]
+
+- See release notes on GitHub
+
+## [3.2.3]
+
+- See release notes on GitHub
+
+## [3.2.2]
+
+- See release notes on GitHub
+
+## [3.2.1]
+
+- See release notes on GitHub
+
+## [3.2.0]
+
+- See release notes on GitHub
+
+## [3.1.1]
+
+- See release notes on GitHub
+
+## [3.1.0]
+
+- See release notes on GitHub
+
+## [3.0.4]
+
+- See release notes on GitHub
+
+## [3.0.3]
+
+- See release notes on GitHub
+
+## [3.0.2]
+
+- See release notes on GitHub
+
+## [3.0.1]
+
+- See release notes on GitHub
+
+## [3.0.0]
+
+- See release notes on GitHub
+
+## [2.3.0]
+
+- See release notes on GitHub
+
+## [2.2.9]
+
+- See release notes on GitHub
+
+## [2.2.8]
+
+- See release notes on GitHub
+
+## [2.2.7]
+
+- See release notes on GitHub
+
+## [2.2.6]
+
+- See release notes on GitHub
+
+## [2.2.5]
+
+- See release notes on GitHub
+
+## [2.2.4]
+
+- See release notes on GitHub
+
+## [2.2.3]
+
+- See release notes on GitHub
+
+## [2.2.2]
+
+- See release notes on GitHub
+
+## [2.2.1]
+
+- See release notes on GitHub
+
+## [2.2.0]
+
+- See release notes on GitHub
+
+## [2.1.2]
+
+- See release notes on GitHub
+
+## [2.1.1]
+
+- See release notes on GitHub
+
+## [2.1.0]
+
+- See release notes on GitHub
+
+## [2.0.37]
+
+- See release notes on GitHub
+
+## [2.0.36]
+
+- See release notes on GitHub
+
+## [2.0.35]
+
+- See release notes on GitHub
+
+## [2.0.34]
+
+- See release notes on GitHub
+
+## [2.0.33]
+
+- See release notes on GitHub
+
+## [2.0.31]
+
+- See release notes on GitHub
+
+## [2.0.30]
+
+- See release notes on GitHub
+
+## [2.0.29]
+
+- See release notes on GitHub
+
+## [2.0.28]
+
+- See release notes on GitHub
+
+## [2.0.27]
+
+- See release notes on GitHub
+
+## [2.0.26]
+
+- See release notes on GitHub
+
+## [2.0.25]
+
+- See release notes on GitHub
+
+## [2.0.24]
+
+- See release notes on GitHub
+
+## [2.0.23]
+
+- See release notes on GitHub
+
+## [2.0.22]
+
+- See release notes on GitHub
+
+## [2.0.21]
+
+- See release notes on GitHub
+
+## [2.0.20]
+
+- See release notes on GitHub
+
+## [2.0.19]
+
+- See release notes on GitHub
+
+## [2.0.18]
+
+- See release notes on GitHub
+
+## [2.0.17]
+
+- See release notes on GitHub
+
+## [2.0.16]
+
+- See release notes on GitHub
+
 ## [2.0.15]
 
 - Allow status led to be disabled (fixes #156) @DTTerastar (#196)
 - Add device configuration url to mqtt discovery
+- Recognize Dexcom sensors (`sd:febc`) and report them as `dexa:{mac}`
 
 ## [2.0.14]
 

--- a/src/BleFingerprint.cpp
+++ b/src/BleFingerprint.cpp
@@ -320,6 +320,9 @@ void BleFingerprint::fingerprintServiceData(NimBLEAdvertisedDevice *advertisedDe
 #endif
                 setId("miTherm:" + getMac(), ID_TYPE_MITHERM);
             }
+        } else if (uuid == dexaUUID) {
+            asRssi = haveTxPower ? BleFingerprintCollection::rxRefRssi + txPower : NO_RSSI;
+            setId("dexa:" + getMac(), ID_TYPE_DEXA);
         } else if (uuid == eddystoneUUID && strServiceData.length() > 0) {
             if (strServiceData[0] == EDDYSTONE_URL_FRAME_TYPE && strServiceData.length() <= 18) {
                 BLEEddystoneURL oBeacon = BLEEddystoneURL();

--- a/src/BleFingerprint.h
+++ b/src/BleFingerprint.h
@@ -50,6 +50,7 @@
 #define ID_TYPE_MEATER short(140)
 #define ID_TYPE_TRACTIVE short(142)
 #define ID_TYPE_VANMOOF short(145)
+#define ID_TYPE_DEXA short(146)
 #define ID_TYPE_APPLE_NEARBY short(150)
 #define ID_TYPE_QUERY_MODEL short(155)
 #define ID_TYPE_QUERY_NAME short(160)

--- a/src/util.h
+++ b/src/util.h
@@ -13,6 +13,7 @@ const BLEUUID sonosUUID((uint16_t)0xFE07);
 const BLEUUID itagUUID((uint16_t)0xffe0);
 const BLEUUID miThermUUID(uint16_t(0x181A));
 const BLEUUID trackrUUID((uint16_t)0x0F3E);
+const BLEUUID dexaUUID((uint16_t)0xFEBC);
 const BLEUUID vanmoofUUID(0x6acc5540, 0xe631, 0x4069, 0x944db8ca7598ad50);
 const BLEUUID tractiveUUID(0x20130001, 0x0719, 0x4b6e, 0xbe5d158ab92fa5a4);
 const BLEUUID espresenseUUID(0xe5ca1ade, 0xf007, 0xba11, 0x0000000000000000);


### PR DESCRIPTION
## Summary
- add `dexaUUID` constant
- fingerprint `sd:febc` service data as `dexa:{mac}`
- include new `ID_TYPE_DEXA`
- note Dexcom support in changelog
- list recent releases in `CHANGELOG.md`

## Testing
- `platformio run -e esp32 -t size`


------
https://chatgpt.com/codex/tasks/task_e_685f39aadb4c8324bfa71884687ffb26