### PR TITLE
Fix WiFi credential parsing

### DIFF
--- a/src/SerialImprov.cpp
+++ b/src/SerialImprov.cpp
@@ -241,15 +241,17 @@ void sendImprovInfoResponse() {
 }
 
 void parseWiFiCommand(char* data) {
-    uint8_t len = data[0];
-    if (!len || len > 126) return;
+    uint8_t data_len = data[0];
+    if (data_len < 2 || data_len > 126) return;
 
     uint8_t ssid_length = data[1];
-    uint8_t ssid_start = 2;
+    size_t ssid_start = 2;
     size_t ssid_end = ssid_start + ssid_length;
+    if (!ssid_length || ssid_end > data_len + 1) return;
 
     uint8_t pass_length = data[ssid_end];
     size_t pass_start = ssid_end + 1;
+    if (pass_length > 126 || pass_start + pass_length > data_len + 1) return;
     size_t pass_end = pass_start + pass_length;
 
     std::string ssid(data + ssid_start, data + ssid_end);


### PR DESCRIPTION
## Summary
- correct Improv serial WiFi credential parsing by honoring data and password boundaries

## Testing
- `pio run -e esp32`


------
https://chatgpt.com/codex/tasks/task_e_68a9b9a79d2c8324a2cc5780caa095b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened validation for WiFi credentials with stricter length limits and boundary checks.
  * Prevents crashes and misconfiguration when SSID/password are malformed, too short, or exceed supported sizes.
  * Improves reliability during pairing and connection flows by safely rejecting invalid inputs.
  * No impact on existing valid credentials; normal setup continues to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->