### PR TITLE
fix: Handle fork PRs gracefully in UI build workflow

### DIFF
--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -45,7 +45,10 @@ jobs:
         echo "changes=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
 
     - name: Create Pull Request
-      if: steps.check_changes.outputs.changes > '0'
+      if: |
+        steps.check_changes.outputs.changes > '0' &&
+        (github.event_name == 'push' ||
+         github.event.pull_request.head.repo.full_name == github.repository)
       uses: peter-evans/create-pull-request@v8
       with:
         commit-message: 'chore: update UI build outputs'
@@ -62,3 +65,12 @@ jobs:
         labels: |
           automated pr
           ui
+
+    - name: Changes detected but skipped (fork PR)
+      if: |
+        steps.check_changes.outputs.changes > '0' &&
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name != github.repository
+      run: |
+        echo "UI build outputs changed, but PR creation is skipped for fork PRs"
+        echo "The PR author should run 'npm run build' locally and commit the changes"


### PR DESCRIPTION
## Summary
Fixes the UI build workflow failure when running on pull requests from forks.

## Problem
The `ui-build.yml` workflow was failing on fork PRs with error: "Resource not accessible by integration". This occurred because the workflow attempted to create a pull request using `GITHUB_TOKEN`, which has restricted permissions on fork PRs.

## Solution
- Added fork detection logic to skip PR creation for fork PRs
- Added informational message when PR creation is skipped
- Workflow now passes cleanly on fork PRs instead of failing

## Behavior
- **Push to master**: Creates PR as before (if UI changes detected)
- **PR from same repo**: Creates PR as before (if UI changes detected)  
- **PR from fork**: Skips PR creation gracefully, shows helpful message

## Testing
This fix can be verified by observing the workflow pass on fork PRs like #1619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to handle fork pull requests differently. Automatic pull request creation is now skipped for forks, with guidance provided to contributors to run the build process locally and commit changes directly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->