### PR TITLE
Add support for WESP32 Rev7 Ethernet with defaults

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -107,11 +107,19 @@
 #define DEFAULT_I2C_BUS_2_SCL -1
 #define DEFAULT_I2C_BUS 1
 #else
+#ifdef WESP32_REV7
+#define DEFAULT_I2C_BUS_1_SDA 15
+#define DEFAULT_I2C_BUS_1_SCL 4
+#define DEFAULT_I2C_BUS_2_SDA 33
+#define DEFAULT_I2C_BUS_2_SCL 5
+#define DEFAULT_I2C_BUS 1
+#else
 #define DEFAULT_I2C_BUS_1_SDA 21
 #define DEFAULT_I2C_BUS_1_SCL 22
 #define DEFAULT_I2C_BUS_2_SDA -1
 #define DEFAULT_I2C_BUS_2_SCL -1
 #define DEFAULT_I2C_BUS 1
+#endif
 #endif
 #endif
 #endif
@@ -154,6 +162,15 @@
 #define DEFAULT_LED1_CNT 1
 
 #define MAX_BRIGHTNESS 20
+
+#elif defined WESP32_REV7
+
+#define DEFAULT_LED1_TYPE 2
+#define DEFAULT_LED1_PIN -1
+#define DEFAULT_LED1_CNTRL Control_Type_Status
+#define DEFAULT_LED1_CNT 1
+
+#define MAX_BRIGHTNESS 100
 
 #else  // DevKit / generic
 

--- a/lib/network/Network.h
+++ b/lib/network/Network.h
@@ -22,7 +22,7 @@ public:
   bool connect(int ethernetType, int wait_seconds, const char *hostName);
 };
 
-#define CONFIG_NUM_ETH_TYPES        13
+#define CONFIG_NUM_ETH_TYPES        14
 
 #define CONFIG_ETH_NONE             0
 #define CONFIG_ETH_WT32_ETH01       1
@@ -37,6 +37,7 @@ public:
 #define CONFIG_ETH_EST_POE_32       10
 #define CONFIG_ETH_LILYGO_LITE_RTL  11
 #define CONFIG_ETH_ESP32_POE_A1     12
+#define CONFIG_ETH_WESP32_REV7      13
 
 // For ESP32, the remaining five pins are at least somewhat configurable.
 // eth_address  is in range [0..31], indicates which PHY (MAC?) address should be allocated to the interface
@@ -143,7 +144,7 @@ const ethernet_settings ethernetBoards[] = {
     ETH_PHY_LAN8720,      // eth_type,
     ETH_CLOCK_GPIO17_OUT  // eth_clk_mode
   },
-  
+
   // GL-inet GL-S10 v2.1 Ethernet
   {
     1,                    // eth_address,
@@ -182,6 +183,16 @@ const ethernet_settings ethernetBoards[] = {
    18,                  // eth_mdio,
    ETH_PHY_LAN8720,     // eth_type,
    ETH_CLOCK_GPIO17_OUT // eth_clk_mode
+  },
+
+   // WESP32-Rev7-Plus
+  {
+    0,			              // eth_address,
+    -1,			              // eth_power,
+    16,			              // eth_mdc,
+    17,			              // eth_mdio,
+    ETH_PHY_RTL8201,      // eth_type,
+    ETH_CLOCK_GPIO0_IN	  // eth_clk_mode
   }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@ void heapCapsAllocFailedHook(size_t requestedSize, uint32_t caps, const char *fu
  * @param totalFpQueried Total fingerprints queried (e.g., looked up) since the last report.
  * @param totalFpReported Total fingerprint reports published since the last report.
  * @param count Current count value (included only when a count identifier is configured).
- * @return `true` if the telemetry document was published successfully, `false` otherwise. 
+ * @return `true` if the telemetry document was published successfully, `false` otherwise.
  * `false` is also returned when telemetry publishing is disabled or the function is rate-limited.
  */
 bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned int totalFpQueried, unsigned int totalFpReported, unsigned int count) {
@@ -167,7 +167,7 @@ void setupNetwork() {
     HeadlessWiFiSettings.pstring("wifi-password", "", "WiFi Password");
     auto wifiTimeout = HeadlessWiFiSettings.integer("wifi_timeout", DEFAULT_WIFI_TIMEOUT, "Seconds to wait for WiFi before captive portal (-1 = forever)");
     auto portalTimeout = 1000UL * HeadlessWiFiSettings.integer("portal_timeout", DEFAULT_PORTAL_TIMEOUT, "Seconds to wait in captive portal before rebooting");
-    std::vector<String> ethernetTypes = {"None", "WT32-ETH01", "ESP32-POE", "WESP32", "QuinLED-ESP32", "TwilightLord-ESP32", "ESP32Deux", "KIT-VE", "LilyGO-T-ETH-POE", "GL-inet GL-S10 v2.1 Ethernet", "EST-PoE-32", "LilyGO-T-ETH-Lite (RTL8201)", "ESP32-POE_A1"};
+    std::vector<String> ethernetTypes = {"None", "WT32-ETH01", "ESP32-POE", "WESP32", "QuinLED-ESP32", "TwilightLord-ESP32", "ESP32Deux", "KIT-VE", "LilyGO-T-ETH-POE", "GL-inet GL-S10 v2.1 Ethernet", "EST-PoE-32", "LilyGO-T-ETH-Lite (RTL8201)", "ESP32-POE_A1", "wESP32 Rev7+ (RTL8201)"};
     ethernetType = HeadlessWiFiSettings.dropdown("eth", ethernetTypes, 0, "Ethernet Type");
 
     mqttHost = HeadlessWiFiSettings.string("mqtt_host", DEFAULT_MQTT_HOST, "Server");

--- a/ui/src/routes/network/+page.svelte
+++ b/ui/src/routes/network/+page.svelte
@@ -187,6 +187,7 @@
                     <option value="10">EST-PoE-32</option>
                     <option value="11">LilyGO-T-ETH-Lite (RTL8201)</option>
                     <option value="12">ESP32-POE_A1</option>
+                    <option value="13">wESP32 Rev7+ (RTL8201)</option>
                 </select>
             </div>
 


### PR DESCRIPTION
This PR adds support for the WESP32 Rev7 board with Ethernet capability and sets the defaults in defaults.h.  The Revision 7 boards use the RTL8201FI with changes is the definition of the PHY.

Tested on an wESP32 Revision 7 board.

Added:

- Added WESP32 Rev7 board 
- Updated UI dropdown to include WESP32 Rev7 as an Ethernet type option
- Added default I2C pin configuration and set the LED to -1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for WESP32 Rev7+ board variant with preconfigured I2C and LED defaults.
  * New "wESP32 Rev7+ (RTL8201)" Ethernet type option available in network settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->