### PR TITLE
Remove unsupported $PRERELEASE_NUMBER from release-drafter version template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-version-template: '$MAJOR.$MINOR.$PATCH$PRERELEASE$PRERELEASE_NUMBER'
+version-template: '$MAJOR.$MINOR.$PATCH$PRERELEASE'
 categories:
   - title: 'Features'
     labels:


### PR DESCRIPTION
### Motivation
- Release Drafter was emitting the literal `$PRERELEASE_NUMBER` in prerelease tags (e.g. `v4.0.1-b.0$PRERELEASE_NUMBER`), so the template must be simplified to avoid unsupported variable usage.

### Description
- Update `.github/release-drafter.yml` to set `version-template: '$MAJOR.$MINOR.$PATCH$PRERELEASE'`, removing `$PRERELEASE_NUMBER`.

### Testing
- No automated tests were run because this is a config-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988b5444790832496d85c2f9d4c7610)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release versioning format to remove the numeric suffix from prerelease versions. Prerelease versions will now follow a simplified naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->