### PR TITLE
Expand PR labeler prefixes

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,8 @@
+feature: ['feature/*', 'feat/*']
+enhancement: ['enhancement/*', 'enhance/*']
+fix: ['fix/*', 'bugfix/*']
+bug: 'bug/*'
+chore: 'chore/*'
+major: 'major/*'
+minor: 'minor/*'
+patch: 'patch/*'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,20 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/pr-labeler.yml


### PR DESCRIPTION
### Motivation
- Align the PR labeler branch-prefix mappings with the repository's common branch prefixes and the `release-drafter` categories so new PRs are labeled reliably.
- Add mappings for enhancement/bugfix/bug and release-version branches to reduce manual labeling and improve changelog categorization.

### Description
- Updated ` .github/pr-labeler.yml` to expand mappings by adding `enhancement: ['enhancement/*','enhance/*']`, `fix: ['fix/*','bugfix/*']`, `bug: 'bug/*'`, and `major`, `minor`, and `patch` mappings for release branches while keeping `feature` and `chore` mappings.
- The existing workflow at ` .github/workflows/pr-labeler.yml` remains configured to run `TimonVS/pr-labeler-action@v5` on `pull_request: opened` and will use the updated configuration file.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988c5b4eecc8324a9475def2649d3f1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pull request labeling system that categorizes pull requests based on branch naming conventions, improving project organization and workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->