### PR TITLE
Disable WiFi persistence in setupNetwork function

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,6 +159,7 @@ bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned in
  */
 void setupNetwork() {
     Log.println("Setup network");
+    WiFi.persistent(false);
     WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
     GUI::Connected(false, false);
 


### PR DESCRIPTION
Disable the persistent wifi setting so mesh routers can switch in and out when one goes away.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WiFi credentials no longer persist across device reboots, ensuring fresh credential handling after each restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->