### PR TITLE
Fix fingerprints page crash when distance/var is null

### DIFF
--- a/ui/src/routes/fingerprints/+page.svelte
+++ b/ui/src/routes/fingerprints/+page.svelte
@@ -22,7 +22,7 @@
         {
             key: "distance",
             title: "Dist",
-            value: (v: Device) => v.distance === undefined ? "n/a" : `${v.distance.toLocaleString(undefined, { minimumFractionDigits: 2 })} m`,
+            value: (v: Device) => v.distance == null ? "n/a" : `${v.distance.toLocaleString(undefined, { minimumFractionDigits: 2 })} m`,
             sortValue: (v: Device) => v.distance ?? Number.POSITIVE_INFINITY,
             sortable: true,
             defaultSort: true,
@@ -31,7 +31,7 @@
         {
             key: "var",
             title: "Var",
-            value: (v: Device) => v.var === undefined ? "n/a" : `${v.var.toLocaleString(undefined, { minimumFractionDigits: 2 })} m`,
+            value: (v: Device) => v.var == null ? "n/a" : `${v.var.toLocaleString(undefined, { minimumFractionDigits: 2 })} m`,
             sortValue: (v: Device) => v.var ?? Number.POSITIVE_INFINITY,
             sortable: true
         },


### PR DESCRIPTION
## Summary
- Fix `TypeError: Cannot read properties of null (reading 'toLocaleString')` on the fingerprints page
- Changed `=== undefined` to `== null` for `distance` and `var` fields so both `null` and `undefined` are handled before calling `.toLocaleString()`

## Test plan
- [ ] Open the fingerprints page with devices that have null distance/var values
- [ ] Verify no console errors and "n/a" is displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of missing values in data columns to properly display "n/a" when data is unavailable
  * Updated default sort order for distance metric to ascending

<!-- end of auto-generated comment: release notes by coderabbit.ai -->