### PR TITLE
Fix crash from unsynchronized fingerprint vector access in scanTask

### DIFF
--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -347,10 +347,10 @@ BleFingerprint *GetFingerprint(BLEAdvertisedDevice *advertisedDevice) {
     return f;
 }
 
-const std::vector<BleFingerprint *> GetCopy() {
+const std::vector<BleFingerprint *> GetCopy(bool cleanup) {
     if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
         log_e("Couldn't take fingerprintMutex!");
-    CleanupOldFingerprints();
+    if (cleanup) CleanupOldFingerprints();
     std::vector<BleFingerprint *> copy(fingerprints);
     xSemaphoreGive(fingerprintMutex);
     return std::move(copy);

--- a/src/BleFingerprintCollection.h
+++ b/src/BleFingerprintCollection.h
@@ -33,7 +33,7 @@ void Count(BleFingerprint *f, bool counting);
 void Seen(BLEAdvertisedDevice *advertisedDevice);
 BleFingerprint *GetFingerprint(BLEAdvertisedDevice *advertisedDevice);
 void CleanupOldFingerprints();
-const std::vector<BleFingerprint *> GetCopy();
+const std::vector<BleFingerprint *> GetCopy(bool cleanup = true);
 bool FindDeviceConfig(const String &id, DeviceConfig &config);
 bool FindDeviceConfigByAlias(const String &alias, DeviceConfig &config);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -551,7 +551,8 @@ void scanTask(void *parameter) {
         log_e("Error starting continuous ble scan");
 
     while (true) {
-        for (auto &f : BleFingerprintCollection::fingerprints)
+        auto queryable = BleFingerprintCollection::GetCopy(false);
+        for (auto &f : queryable)
             if (f->query())
                 totalFpQueried++;
 


### PR DESCRIPTION
## Summary
- **scanTask** iterated `BleFingerprintCollection::fingerprints` directly without taking `fingerprintMutex`, while the main loop's `CleanupOldFingerprints()` could delete objects and erase entries from the same vector
- This caused iterator invalidation and use-after-free, crashing with "Load access fault" at address `0x00000002` on ESP32-C3 (null pointer dereference in ROM string function)
- Added a `cleanup` parameter to `GetCopy()` (default `true` for backward compatibility) and use `GetCopy(false)` in scanTask to take a mutex-protected snapshot without triggering cleanup

## Test plan
- [ ] Build passes for esp32c3 (verified locally)
- [ ] Deploy to ESP32-C3 node and confirm no more Guru Meditation panics during normal BLE scanning/querying
- [ ] Verify fingerprint cleanup still works correctly from the main loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced data retrieval operations to support optional cleanup behavior, providing more granular control over when resource maintenance tasks are executed and improving flexibility in resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->