### PR TITLE
Fix unsynchronized fingerprint vector access in Config()

### DIFF
--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -174,6 +174,8 @@ bool Config(String &id, String &json) {
         }
     }
 
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+        log_e("Couldn't take fingerprintMutex in Config!");
     for (auto &it : fingerprints) {
         auto it_id = it->getId();
         if (it_id == id || it_id == config.alias) {
@@ -184,6 +186,7 @@ bool Config(String &id, String &json) {
         } else
             it->fingerprintAddress();
     }
+    xSemaphoreGive(fingerprintMutex);
 
     return true;
 }


### PR DESCRIPTION
## Problem

`Config()` in `BleFingerprintCollection.cpp` was iterating over the `fingerprints` vector without holding `fingerprintMutex`:

```cpp
for (auto &it : fingerprints) {   // NO MUTEX!
    auto it_id = it->getId();
    ...
    it->fingerprintAddress();     // also reads irks vector
}
```

This is the same race condition fixed for `scanTask` in #2127 — BLE scanner callbacks on another core can call `GetFingerprint()` which pushes to / searches the same vector concurrently.

## Fix

Wrap the loop with `fingerprintMutex`, matching the pattern used by `GetFingerprint()` and `GetCopy()`.

```cpp
if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
    log_e("Couldn't take fingerprintMutex in Config!");
for (auto &it : fingerprints) {
    ...
}
xSemaphoreGive(fingerprintMutex);
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety in BLE fingerprint collection configuration to enhance system reliability during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->