### PR TITLE
ci: restrict HIL pipeline to PRs and main branch pushes

### DIFF
--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -1,5 +1,8 @@
 when:
-  - event: [push, pull_request]
+  - event: pull_request
+    repo: ESPresense/ESPresense
+  - event: push
+    branch: main
 
 steps:
   - name: test-esp32


### PR DESCRIPTION
Narrows the Woodpecker CI HIL pipeline triggers to only run on pull requests and pushes to `main`, rather than all branch pushes. This avoids unnecessary hardware-in-the-loop test runs on feature branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to improve build and test triggering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->