### PR TITLE
fix: replace OneWire with OneWireNg for broader ESP32 compatibility

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,6 +9,7 @@ extra_configs = platformio_override.ini
 [common]
 lib_ldf_mode = chain
 lib_compat_mode = strict
+lib_ignore = OneWire
 check_tool = cppcheck, clangtidy
 check_flags = clangtidy: --config-file=.clang-tidy
 check_skip_packages = yes
@@ -127,7 +128,7 @@ lib_deps =
   sparkfun/SparkFun SGP30 Arduino Library@^1.0.5
   Sensirion/Sensirion I2C SCD4x@^1.0.0
   sensirion/arduino-sht@^1.2.2
-  paulstoffregen/OneWire@^2.3.7
+  pstolarz/OneWireNg@^0.14.1
   milesburton/DallasTemperature@^3.11.0
 
 [env:esp32]


### PR DESCRIPTION
## Problem
`paulstoffregen/OneWire` 2.3.8 uses direct GPIO register access that is incompatible with ESP32-C6 (and potentially future ESP32 variants).

## Changes
- Replace `paulstoffregen/OneWire@^2.3.7` with `pstolarz/OneWireNg@^0.14.1`
- Add `lib_ignore = OneWire` to prevent the old library being pulled in as a transitive dependency
- OneWireNg provides a drop-in `OneWire.h` compatible interface and supports all ESP32 variants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OneWire library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->