### PR TITLE
fix: format specifier corrections and HeadlessWiFiSettings bump

### DIFF
--- a/lib/utils/string_utils.h
+++ b/lib/utils/string_utils.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <cstring>
 
-#define CHIPID (uint32_t)(ESP.getEfuseMac() >> 24)
+#define CHIPID (unsigned int)(ESP.getEfuseMac() >> 24)
 #define ESPMAC (Sprintf("%06x", CHIPID))
 #define Sprintf(f, ...) ({ char* s; asprintf(&s, f, __VA_ARGS__); const String r = s; free(s); r; })
 #define Stdprintf(f, ...) ({ char* s; asprintf(&s, f, __VA_ARGS__); const std::string r = s; free(s); r; })

--- a/platformio.ini
+++ b/platformio.ini
@@ -56,7 +56,7 @@ framework = arduino
 lib_deps =
   ESP32Async/AsyncTCP@3.4.9
   ESP32Async/ESPAsyncWebServer@3.9.3
-  https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.3
+  https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.4
   https://github.com/ESPresense/NimBLE-Arduino.git#1.4.0
   marvinroger/AsyncMqttClient@^0.9.0
   bblanchon/ArduinoJson@^6.21.5

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 
 void heapCapsAllocFailedHook(size_t requestedSize, uint32_t caps, const char *functionName)
 {
-    printf("%s was called but failed to allocate %d bytes with 0x%X capabilities. \n",functionName, requestedSize, caps);
+    printf("%s was called but failed to allocate %zu bytes with 0x%lX capabilities. \n", functionName, requestedSize, static_cast<unsigned long>(caps));
 }
 
 /**
@@ -588,7 +588,7 @@ void setup() {
 #else
     esp_log_level_set("*", ESP_LOG_ERROR);
 #endif
-    Log.printf("Pre-Setup Free Mem: %d\r\n", ESP.getFreeHeap());
+    Log.printf("Pre-Setup Free Mem: %lu\r\n", static_cast<unsigned long>(ESP.getFreeHeap()));
     heap_caps_register_failed_alloc_callback(heapCapsAllocFailedHook);
 
 #if M5STICK
@@ -625,7 +625,7 @@ void setup() {
 #endif
     xTaskCreatePinnedToCore(scanTask, "scanTask", SCAN_TASK_STACK_SIZE, nullptr, 1, &scanTaskHandle, CONFIG_BT_NIMBLE_PINNED_TO_CORE);
     reportSetup();
-    Log.printf("Post-Setup Free Mem: %d\r\n", ESP.getFreeHeap());
+    Log.printf("Post-Setup Free Mem: %lu\r\n", static_cast<unsigned long>(ESP.getFreeHeap()));
     Log.println();
 }
 
@@ -646,7 +646,7 @@ void loop() {
     if (millis() - lastSlowLoop > 5000) {
         lastSlowLoop = millis();
         auto freeHeap = ESP.getFreeHeap();
-        if (freeHeap < 20000) Log.printf("Low memory: %u bytes free\r\n", freeHeap);
+        if (freeHeap < 20000) Log.printf("Low memory: %lu bytes free\r\n", static_cast<unsigned long>(freeHeap));
         if (freeHeap > 70000) Updater::Loop();
     }
     GUI::Loop();


### PR DESCRIPTION
- Fix `printf` format specifiers (`%d`/`%u` → `%zu`/`%lu`) for `size_t` and heap values to silence `-Wformat` warnings on stricter toolchains
- Cast `uint32_t caps` to `unsigned long` for `%lX` in the alloc-failed hook
- Change `CHIPID` cast from `uint32_t` to `unsigned int` for format compatibility
- Bump HeadlessWiFiSettings `v1.1.3` → `v1.1.4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency library to latest version for improved stability and compatibility.

* **Bug Fixes**
  * Corrected memory reporting output formatting to ensure accurate display of system memory information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->