### PR TITLE
fix: skip BLE query while enrollment is active

### DIFF
--- a/src/BleFingerprint.cpp
+++ b/src/BleFingerprint.cpp
@@ -7,6 +7,7 @@
 #include "MiFloraHandler.h"
 #include "NameModelHandler.h"
 #include "defaults.h"
+#include "globals.h"
 #include "Logger.h"
 #include "mbedtls/aes.h"
 #include "rssi.h"
@@ -602,7 +603,7 @@ bool BleFingerprint::report(JsonObject *doc) {
  * @returns `true` if a query attempt was initiated, `false` otherwise.
  */
 bool BleFingerprint::query() {
-    if (!allowQuery || isQuerying) return false;
+    if (!allowQuery || isQuerying || enrolling) return false;
     if (rssi < -90) return false; // Too far away
 
     auto now = millis();


### PR DESCRIPTION
## Problem

With `CONFIG_BT_NIMBLE_MAX_CONNECTIONS=2` (#2142), NimBLE's connection pool has exactly 2 slots:
- Slot 1: enrollment **server** peripheral connection  
- Slot 2: `query()` **client** outbound connection (MiFlora / NameModel)

If `query()` is attempted while enrollment already holds a server slot, `NimBLEDevice::createClient()` hits the connection limit in NimBLE 1.4.0. This corrupts NimBLE's internal connection pool, which eventually manifests as TLSF heap block metadata corruption. The corruption is detected ~73 minutes later when `lwIP`'s TCP stack tries to free a TIME_WAIT connection:

```
tlsf_free → block_merge_next → block_is_free  ← Load access fault at 0x7f98f388
```

## Fix

Guard `query()` with the global `enrolling` flag. Queries back off for the ~2 minute enrollment window and resume once enrollment ends.

Closes #2146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added state validation to prevent fingerprint queries during enrollment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->