### PR TITLE
Fix websocket JSON buffer overflow

### DIFF
--- a/src/HttpWebServer.cpp
+++ b/src/HttpWebServer.cpp
@@ -101,7 +101,7 @@ void sendDataWs(AsyncWebSocketClient *client) {
             ws.cleanupClients(0);  // disconnect all clients to release memory
             return;                // out of memory
         }
-        serializeJson(doc, (char *)buffer->get(), len + 1);
+        serializeJson(doc, buffer->get(), len);
     }
     if (client) {
         client->text(buffer);


### PR DESCRIPTION
## Summary
- fix AsyncWebSocket JSON serialization to write exactly the measured payload length
- avoid writing a trailing NUL past the allocated websocket buffer

## Testing
- not run (PlatformIO pio command is not installed in this shell)