### PR TITLE
feat: add fingerprint count to telemetry

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,7 @@ void heapCapsAllocFailedHook(size_t requestedSize, uint32_t caps, const char *fu
  * @return `true` if the telemetry document was published successfully, `false` otherwise.
  * `false` is also returned when telemetry publishing is disabled or the function is rate-limited.
  */
-bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned int totalFpQueried, unsigned int totalFpReported, unsigned int count) {
+bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned int totalFpQueried, unsigned int totalFpReported, unsigned int count, unsigned int fingerprintCount) {
     if (!online) {
         if (
             pub(statusTopic.c_str(), 0, true, "online")
@@ -135,6 +135,7 @@ bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned in
     auto freeHeap = ESP.getFreeHeap();
     doc["freeHeap"] = freeHeap;
     doc["maxHeap"] = maxHeap;
+    doc["fingerprints"] = fingerprintCount;
     doc["scanStack"] = uxTaskGetStackHighWaterMark(scanTaskHandle);
     doc["loopStack"] = uxTaskGetStackHighWaterMark(nullptr);
     doc["bleStack"] = bleStack;
@@ -505,7 +506,7 @@ void reportLoop() {
     GUI::Count(count);
 
     yield();
-    sendTelemetry(totalSeen, totalFpSeen, totalFpQueried, totalFpReported, count);
+    sendTelemetry(totalSeen, totalFpSeen, totalFpQueried, totalFpReported, count, copy.size());
     yield();
 
     auto reported = 0;


### PR DESCRIPTION
Adds `fingerprints` field to telemetry JSON containing the current size of the tracked fingerprints collection.

Useful for monitoring BLE tracking load and capacity utilization in production deployments.

**Example telemetry output:**
```json
{
  "freeHeap": 245632,
  "maxHeap": 327680,
  "fingerprints": 42,
  "scanStack": 1024,
  ...
}
```

This is a standalone addition extracted from #2051 for faster merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry now includes a new "fingerprints" metric alongside existing memory metrics for more comprehensive monitoring.
  * Telemetry payloads and reporting reflect actual fingerprint counts so external dashboards and logs show the updated metric for better observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->