### PR TITLE
Enable compiler exceptions

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,6 @@ debug_build_flags = -Og -ggdb3 -g3 -DDEBUG_TLS_MEM
 build_flags =
   -free
   -fipa-pta
-  -fno-exceptions
   -flto=auto
   -fpermissive
   -Wall
@@ -50,7 +49,6 @@ build_unflags =
   -Wincompatible-pointer-types
   -Wnonnull-compare
   -Wformat-nonliteral
-  -fexceptions
   -fno-lto
 framework = arduino
 lib_deps =


### PR DESCRIPTION
## Summary
- remove the explicit -fno-exceptions compiler flag from the shared PlatformIO build flags
- stop unflagging -fexceptions so the toolchain/framework default exception support can remain enabled

## Testing
- Not run locally: python3 -m platformio run -e esp32 is currently blocked in this environment by missing PlatformIO framework headers (xtensa/hal.h, esp_compiler.h, freertos/FreeRTOS.h)
- HIL requested by maintainer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->