### PR TITLE
Migrate MQTT client to PsychicMqttClient

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -66,7 +66,7 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer@3.9.3
   https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.5
   https://github.com/ESPresense/NimBLE-Arduino.git#1.4.0
-  https://github.com/ESPresense/async-mqtt-client.git#v0.9.3
+  https://github.com/theelims/PsychicMqttClient.git#4bc0336d1ecbc0e778f93e033c65273388204180
   bblanchon/ArduinoJson@^6.21.5
   kitesurfer1404/WS2812FX@^1.4.2
 board_build.partitions = partitions_singleapp.csv
@@ -119,7 +119,7 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer@3.9.3
   https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.4
   h2zero/NimBLE-Arduino@^2.3.7
-  https://github.com/ESPresense/async-mqtt-client.git#v0.9.3
+  https://github.com/theelims/PsychicMqttClient.git#4bc0336d1ecbc0e778f93e033c65273388204180
   bblanchon/ArduinoJson@^6.21.5
   kitesurfer1404/WS2812FX@^1.4.2
 build_flags =
@@ -153,7 +153,7 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer@3.9.3
   https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.5
   h2zero/NimBLE-Arduino@^2.3.7
-  https://github.com/ESPresense/async-mqtt-client.git#v0.9.3
+  https://github.com/theelims/PsychicMqttClient.git#4bc0336d1ecbc0e778f93e033c65273388204180
   bblanchon/ArduinoJson@^6.21.5
   kitesurfer1404/WS2812FX@^1.4.2
 build_flags =

--- a/src/BH1750.cpp
+++ b/src/BH1750.cpp
@@ -5,7 +5,7 @@
 #include "mqtt.h"
 #include "defaults.h"
 #include <HeadlessWiFiSettings.h>
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include "string_utils.h"
 
 #include <hp_BH1750.h>

--- a/src/BH1750.h
+++ b/src/BH1750.h
@@ -3,7 +3,7 @@
 #include <ArduinoJson.h>
 
 // Forward declares
-class AsyncMqttClient;
+class PsychicMqttClient;
 
 namespace BH1750
 {

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -1,6 +1,6 @@
 #include "Button.h"
 
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include <HeadlessWiFiSettings.h>
 
 #include "GUI.h"

--- a/src/DHT.cpp
+++ b/src/DHT.cpp
@@ -5,7 +5,7 @@
 #include "mqtt.h"
 #include "defaults.h"
 #include <HeadlessWiFiSettings.h>
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include "string_utils.h"
 
 #include <DHTesp.h>

--- a/src/DS18B20.cpp
+++ b/src/DS18B20.cpp
@@ -5,7 +5,7 @@
 #include "mqtt.h"
 #include "defaults.h"
 #include <HeadlessWiFiSettings.h>
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include "string_utils.h"
 
 #include <DallasTemperature.h>

--- a/src/HX711.cpp
+++ b/src/HX711.cpp
@@ -5,7 +5,7 @@
 #include "mqtt.h"
 #include "defaults.h"
 #include <HeadlessWiFiSettings.h>
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include "string_utils.h"
 
 namespace HX711

--- a/src/LEDs.cpp
+++ b/src/LEDs.cpp
@@ -1,6 +1,6 @@
 #include "LEDs.h"
 
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include <HeadlessWiFiSettings.h>
 #include <WS2812FX.h>
 

--- a/src/MiFloraHandler.h
+++ b/src/MiFloraHandler.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <ArduinoJson.h>
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include <HeadlessWiFiSettings.h>
 #include "BleFingerprint.h"
 #include <NimBLEClient.h>

--- a/src/Motion.cpp
+++ b/src/Motion.cpp
@@ -1,6 +1,6 @@
 #include "Motion.h"
 
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include <HeadlessWiFiSettings.h>
 
 #include "GUI.h"

--- a/src/NameModelHandler.h
+++ b/src/NameModelHandler.h
@@ -2,7 +2,7 @@
 #include <NimBLEClient.h>
 #include <NimBLEDevice.h>
 #include <ArduinoJson.h>
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include "BleFingerprint.h"
 #include <HeadlessWiFiSettings.h>
 

--- a/src/SerialImprov.cpp
+++ b/src/SerialImprov.cpp
@@ -1,4 +1,4 @@
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include <HeadlessWiFiSettings.h>
 
 #include <cstdio>

--- a/src/Switch.cpp
+++ b/src/Switch.cpp
@@ -1,6 +1,6 @@
 #include "Switch.h"
 
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include <HeadlessWiFiSettings.h>
 
 #include "GUI.h"

--- a/src/TSL2561.cpp
+++ b/src/TSL2561.cpp
@@ -5,7 +5,7 @@
 #include "mqtt.h"
 #include "TSL2561.h"
 #include <HeadlessWiFiSettings.h>
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include <Adafruit_TSL2561_U.h>
 #include "string_utils.h"
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <Arduino.h>
-#include <AsyncMqttClient.h>
+#include <PsychicMqttClient.h>
 #include <ESPAsyncWebServer.h>
 #include <ArduinoJson.h>
 #include "Logger.h"
@@ -29,7 +29,7 @@ Setup variable declaration macros.
 #endif
 
 _DECL String room, id, statusTopic, teleTopic, roomsTopic, setTopic, configTopic;
-_DECL AsyncMqttClient mqttClient;
+_DECL PsychicMqttClient mqttClient;
 _DECL String homeAssistantDiscoveryPrefix;
 _DECL DynamicJsonDocument doc _INIT_N(((768)));
 _DECL String localIp;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -328,6 +328,9 @@ void onMqttDisconnect(bool sessionPresent) {
     (void)sessionPresent;
     GUI::Connected(true, false);
     Log.println("Disconnected from MQTT");
+    // The library owns reconnection now, but reconnectTries is still reported in
+    // telemetry; count disconnects here so the counter doesn't go permanently dead.
+    reconnectTries++;
     online = false;
 }
 
@@ -661,6 +664,18 @@ void loop() {
                 break;
             case HeapTrip::None:
                 break;
+        }
+
+        // PsychicMqttClient owns MQTT reconnect, but nothing supervises the link itself
+        // any more -- the 3s reconnect timer this migration deleted was also what
+        // restarted a node whose wifi or broker never came back. Reuse this tick for it.
+        // ponytail: one flat timeout, add backoff or a /set override only if reboot loops show up.
+        static uint16_t offlinePasses = 0;
+        if (MultiNetwork.isOnline() && mqttClient.connected()) {
+            offlinePasses = 0;
+        } else if (++offlinePasses > 60) {  // 60 * 5s = 5 minutes
+            Log.println("Offline for 5 minutes, restarting");
+            ESP.restart();
         }
     }
     GUI::Loop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -310,7 +310,6 @@ void setupNetwork() {
 }
 
 void onMqttConnect(bool sessionPresent) {
-    xTimerStop(reconnectTimer, 0);
     mqttClient.subscribe("espresense/rooms/*/+/set", 1);
     mqttClient.subscribe(setTopic.c_str(), 1);
     mqttClient.subscribe(configTopic.c_str(), 1);
@@ -318,16 +317,17 @@ void onMqttConnect(bool sessionPresent) {
 }
 
 /**
- * @brief Handle MQTT disconnection events and initiate reconnection.
+ * @brief Handle MQTT disconnection events.
  *
- * Updates the GUI to show disconnected status, logs the disconnect reason, starts the reconnect timer, and marks the device as offline.
+ * Updates the GUI to show disconnected status and marks the device as offline.
+ * MQTT reconnection is handled by the client library's auto-reconnect logic.
  *
- * @param reason The MQTT client's disconnection reason code.
+ * @param sessionPresent MQTT session state reported by the client.
  */
-void onMqttDisconnect(AsyncMqttClientDisconnectReason reason) {
+void onMqttDisconnect(bool sessionPresent) {
+    (void)sessionPresent;
     GUI::Connected(true, false);
-    Log.printf("Disconnected from MQTT; reason %d\r\n", (int)reason);
-    xTimerStart(reconnectTimer, 0);
+    Log.println("Disconnected from MQTT");
     online = false;
 }
 
@@ -396,70 +396,30 @@ void onMqttMessage(const char *topic, const char *payload) {
     }
 }
 
-std::string payload_buffer_;
 /**
- * @brief Reassembles chunked MQTT message payloads and dispatches the complete message.
+ * @brief Dispatches a fully reassembled MQTT message payload.
  *
- * Buffers incoming payload fragments until the full MQTT message has been received; when the final fragment arrives, calls onMqttMessage with the original topic and the reconstructed payload, then clears the buffer.
+ * PsychicMqttClient reassembles multipart payloads before invoking the callback,
+ * so this adapter simply forwards the topic and payload to the existing handler.
  *
  * @param topic Topic string associated with the incoming MQTT message.
- * @param payload Pointer to the current fragment's data.
- * @param properties MQTT message properties for the current fragment.
- * @param len Length in bytes of the current fragment.
- * @param index Byte offset of the current fragment within the full message.
- * @param total Total size in bytes of the full MQTT message.
+ * @param payload Null-terminated MQTT payload string.
  */
-void onMqttMessageRaw(char *topic, char *payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {
-    if (index == 0)
-        payload_buffer_.reserve(total);
-
-    // append new payload, may contain incomplete MQTT message
-    payload_buffer_.append(payload, len);
-
-    // MQTT fully received
-    if (len + index == total) {
-        onMqttMessage(topic, payload_buffer_.data());
-        payload_buffer_.clear();
-    }
-}
-
-/**
- * @brief Attempts to re-establish network and MQTT connectivity, restarting the device on repeated failure.
- *
- * If both network and MQTT are already connected the function returns immediately.
- * The function increments an internal reconnect-attempt counter and restarts the device after more than 50 attempts.
- * When the network is disconnected it tries to restore connectivity using configured Ethernet or Wi‑Fi settings; failing to restore the network triggers a device restart.
- * After ensuring network connectivity it initiates an MQTT connection attempt.
- *
- * @param xTimer FreeRTOS timer handle associated with the reconnect timer (unused).
- */
-void reconnect(TimerHandle_t xTimer) {
-    Log.printf("%u Reconnect timer\r\n", xPortGetCoreID());
-    if (MultiNetwork.isOnline() && mqttClient.connected()) return;
-
-    if (reconnectTries++ > 50) {
-        Log.println("Too many reconnect attempts; Restarting");
-        ESP.restart();
-    }
-
-    if (!MultiNetwork.isOnline()) {
-        Log.printf("%u Reconnecting to Network...\r\n", xPortGetCoreID());
-
-        if (!MultiNetwork.connect(ethernetType, 2, 40, HeadlessWiFiSettings.hostname.c_str()))
-            ESP.restart();
-    }
-
-    Log.printf("%u Reconnecting to MQTT...\r\n", xPortGetCoreID());
-    mqttClient.connect();
+void onMqttMessageRaw(char *topic, char *payload, int retain, int qos, bool dup) {
+    (void)retain;
+    (void)qos;
+    (void)dup;
+    onMqttMessage(topic, payload);
 }
 
 void connectToMqtt() {
-    reconnectTimer = xTimerCreate("reconnectionTimer", pdMS_TO_TICKS(3000), pdTRUE, (void *)nullptr, reconnect);
+    mqttClient.setAutoReconnect(true);
     mqttClient.onConnect(onMqttConnect);
     mqttClient.onDisconnect(onMqttDisconnect);
     mqttClient.onMessage(onMqttMessageRaw);
     mqttClient.setClientId(HeadlessWiFiSettings.hostname.c_str());
-    mqttClient.setServer(mqttHost.c_str(), mqttPort);
+    mqttUri = Sprintf("mqtt://%s:%u", mqttHost.c_str(), mqttPort);
+    mqttClient.setServer(mqttUri.c_str());
     mqttClient.setWill(statusTopic.c_str(), 0, true, "offline");
     mqttClient.setCredentials(mqttUser.c_str(), mqttPass.c_str());
     mqttClient.connect();
@@ -469,7 +429,7 @@ bool reportBuffer(BleFingerprint *f) {
     if (!mqttClient.connected()) return false;
     auto report = f->getReport();
     String const topic = Sprintf(CHANNEL "/devices/%s/%s/%s", f->getId().c_str(), id.c_str(), report.getId().c_str());
-    return mqttClient.publish(topic.c_str(), 0, false, report.getPayload().c_str());
+    return mqttClient.publish(topic.c_str(), 0, false, report.getPayload().c_str()) >= 0;
 }
 
 bool reportDevice(BleFingerprint *f) {

--- a/src/main.h
+++ b/src/main.h
@@ -7,7 +7,6 @@
 #include <SPIFFS.h>
 #include <WiFi.h>
 #include <freertos/FreeRTOS.h>
-#include <freertos/timers.h>
 
 #include "Battery.h"
 #include "BleFingerprint.h"
@@ -52,7 +51,6 @@
 #include "DS18B20.h"
 #endif
 
-TimerHandle_t reconnectTimer;
 TaskHandle_t scanTaskHandle;
 
 unsigned long updateStartedMillis = 0;
@@ -65,7 +63,7 @@ bool sentDiscovery = false;  // Have we successfully sent discovery
 UBaseType_t bleStack = 0;
 
 int ethernetType = 0;
-String mqttHost, mqttUser, mqttPass;
+String mqttHost, mqttUser, mqttPass, mqttUri;
 uint16_t mqttPort;
 
 bool discovery, publishTele, publishDevices;

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -8,9 +8,11 @@
 
 bool pub(const char *topic, uint8_t qos, bool retain, const char *payload, size_t length, bool dup, uint16_t message_id)
 {
+    (void)dup;
+    (void)message_id;
     for (int i = 0; i < 10; i++)
     {
-        if (mqttClient.publish(topic, qos, retain, payload, length, dup, message_id))
+        if (mqttClient.publish(topic, qos, retain, payload, length) >= 0)
             return true;
         delay(25);
     }
@@ -20,9 +22,9 @@ bool pub(const char *topic, uint8_t qos, bool retain, const char *payload, size_
 bool pub(const char *topic, uint8_t qos, bool retain, JsonVariantConst jsonDoc, bool dup, uint16_t message_id)
 {
     // Heap-allocate the serialized payload rather than using a VLA on the
-    // caller's FreeRTOS task stack. AsyncMqttClient copies the payload
-    // synchronously into its own std::vector inside PublishOutPacket's ctor
-    // before publish() returns, so the buffer can be freed immediately.
+    // caller's FreeRTOS task stack. PsychicMqttClient hands the payload to
+    // esp_mqtt_client_publish(), which copies it into the esp-mqtt outbox
+    // before returning, so the buffer can be freed immediately.
     //
     // Motivation: fleet-wide MQTT sessions on WROVER nodes were being
     // dropped by the broker with "Invalid PUBLISH (QoS=0 and DUP=1)" /


### PR DESCRIPTION
## Summary
- replace AsyncMqttClient with PsychicMqttClient in PlatformIO deps and includes
- adapt MQTT setup and callback signatures to the new client API
- use the library's built-in auto-reconnect instead of the custom timer reconnect path

## Verification
- pio run -e esp32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched MQTT client implementation and streamlined connection/reconnect behavior, including server URI usage.

* **Bug Fixes**
  * Tightened publish success detection and reinforced retries.
  * Added allocation and exception guards to avoid failures when system memory is low.

* **Performance**
  * Replaced full-copy iterations with snapshot-based iteration to reduce memory use and stabilize scanning/reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->