### PR TITLE
Bound BLE fingerprint memory usage

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -69,6 +69,7 @@
 #define DEFAULT_COUNT_EXIT 4.0f
 #define DEFAULT_COUNT_MS 10000
 #define DEFAULT_COUNT_IDS ""
+#define DEFAULT_MAX_FINGERPRINTS 256
 
 // RX_ADJ_RSSI Defaults
 #ifdef M5STICK
@@ -177,4 +178,3 @@
 #define MAX_BRIGHTNESS 100
 
 #endif
-

--- a/src/BleFingerprint.cpp
+++ b/src/BleFingerprint.cpp
@@ -22,7 +22,11 @@ class ClientCallbacks : public BLEClientCallbacks {
 
 static ClientCallbacks clientCB;
 
+#ifdef NIMBLE_V2
+BleFingerprint::BleFingerprint(const NimBLEAdvertisedDevice *advertisedDevice) {
+#else
 BleFingerprint::BleFingerprint(BLEAdvertisedDevice *advertisedDevice) {
+#endif
     firstSeenMillis = millis();
     address = NimBLEAddress(advertisedDevice->getAddress());
     addressType = advertisedDevice->getAddressType();
@@ -134,7 +138,11 @@ const int BleFingerprint::get1mRssi() const {
     return BleFingerprintCollection::rxRefRssi + DEFAULT_TX;
 }
 
-void BleFingerprint::fingerprint(NimBLEAdvertisedDevice *advertisedDevice) {
+#ifdef NIMBLE_V2
+void BleFingerprint::fingerprint(const NimBLEAdvertisedDevice *advertisedDevice) {
+#else
+void BleFingerprint::fingerprint(BLEAdvertisedDevice *advertisedDevice) {
+#endif
     if (advertisedDevice->haveName()) {
         const std::string name = advertisedDevice->getName();
         if (!name.empty()) setId(String("name:") + kebabify(name).c_str(), ID_TYPE_NAME, String(name.c_str()));
@@ -236,9 +244,9 @@ void BleFingerprint::fingerprintAddress() {
                 if ((naddress[5] & 0xc0) == 0xc0)
                     setId(mac, ID_TYPE_RAND_STATIC_MAC);
                 else {
-                    auto irks = BleFingerprintCollection::irks;
-                    auto it = std::find_if(irks.begin(), irks.end(), [naddress](uint8_t *irk) { return ble_ll_resolv_rpa(naddress, irk); });
-                    if (it != irks.end()) {
+                    const auto &knownIrks = BleFingerprintCollection::irks;
+                    auto it = std::find_if(knownIrks.begin(), knownIrks.end(), [naddress](uint8_t *irk) { return ble_ll_resolv_rpa(naddress, irk); });
+                    if (it != knownIrks.end()) {
                         auto irk_hex = hexStr(*it, 16);
                         setId(String("irk:") + irk_hex.c_str(), ID_TYPE_KNOWN_IRK);
                         break;
@@ -268,7 +276,11 @@ void BleFingerprint::fingerprintAddress() {
  * @param haveTxPower True if a TX power value is present in the advertisement; otherwise false.
  * @param txPower Advertised TX power in dBm (typically a negative value) when `haveTxPower` is true.
  */
-void BleFingerprint::fingerprintServiceAdvertisements(NimBLEAdvertisedDevice *advertisedDevice, size_t serviceAdvCount, bool haveTxPower, int8_t txPower) {
+#ifdef NIMBLE_V2
+void BleFingerprint::fingerprintServiceAdvertisements(const NimBLEAdvertisedDevice *advertisedDevice, size_t serviceAdvCount, bool haveTxPower, int8_t txPower) {
+#else
+void BleFingerprint::fingerprintServiceAdvertisements(BLEAdvertisedDevice *advertisedDevice, size_t serviceAdvCount, bool haveTxPower, int8_t txPower) {
+#endif
     for (auto i = 0; i < serviceAdvCount; i++) {
         auto uuid = advertisedDevice->getServiceUUID(i);
 #ifdef VERBOSE
@@ -339,7 +351,11 @@ void BleFingerprint::fingerprintServiceAdvertisements(NimBLEAdvertisedDevice *ad
  * @param haveTxPower True if the advertisement included TX power; used to adjust RSSI reference candidates.
  * @param txPower The advertised TX power value (in dBm) when haveTxPower is true.
  */
-void BleFingerprint::fingerprintServiceData(NimBLEAdvertisedDevice *advertisedDevice, size_t serviceDataCount, bool haveTxPower, int8_t txPower) {
+#ifdef NIMBLE_V2
+void BleFingerprint::fingerprintServiceData(const NimBLEAdvertisedDevice *advertisedDevice, size_t serviceDataCount, bool haveTxPower, int8_t txPower) {
+#else
+void BleFingerprint::fingerprintServiceData(BLEAdvertisedDevice *advertisedDevice, size_t serviceDataCount, bool haveTxPower, int8_t txPower) {
+#endif
     asRssi = haveTxPower ? BleFingerprintCollection::rxRefRssi + txPower : NO_RSSI;
     String fingerprint = "";
     for (int i = 0; i < serviceDataCount; i++) {
@@ -434,7 +450,11 @@ void BleFingerprint::fingerprintServiceData(NimBLEAdvertisedDevice *advertisedDe
  * @param haveTxPower True if the advertisement included a TX power field; used to adjust RSSI candidates.
  * @param txPower The TX power value from the advertisement (meaningful only when haveTxPower is true).
  */
-void BleFingerprint::fingerprintManufactureData(NimBLEAdvertisedDevice *advertisedDevice, bool haveTxPower, int8_t txPower) {
+#ifdef NIMBLE_V2
+void BleFingerprint::fingerprintManufactureData(const NimBLEAdvertisedDevice *advertisedDevice, bool haveTxPower, int8_t txPower) {
+#else
+void BleFingerprint::fingerprintManufactureData(BLEAdvertisedDevice *advertisedDevice, bool haveTxPower, int8_t txPower) {
+#endif
     std::string strManufacturerData = advertisedDevice->getManufacturerData();
 #ifdef VERBOSE
     Log.printf("Verbose | %s | %-58s%.1fdBm MD: %s\r\n", getMac().c_str(), getId().c_str(), rssi, hexStr(strManufacturerData).c_str());
@@ -516,7 +536,11 @@ void BleFingerprint::fingerprintManufactureData(NimBLEAdvertisedDevice *advertis
     }
 }
 
+#ifdef NIMBLE_V2
+bool BleFingerprint::seen(const NimBLEAdvertisedDevice *advertisedDevice) {
+#else
 bool BleFingerprint::seen(BLEAdvertisedDevice *advertisedDevice) {
+#endif
     lastSeenMillis = millis();
     reported = false;
 

--- a/src/BleFingerprint.h
+++ b/src/BleFingerprint.h
@@ -66,9 +66,13 @@
 
 class BleFingerprint {
    public:
-    BleFingerprint(NimBLEAdvertisedDevice *advertisedDevice);
-
+#ifdef NIMBLE_V2
+    BleFingerprint(const NimBLEAdvertisedDevice *advertisedDevice);
+    bool seen(const NimBLEAdvertisedDevice *advertisedDevice);
+#else
+    BleFingerprint(BLEAdvertisedDevice *advertisedDevice);
     bool seen(BLEAdvertisedDevice *advertisedDevice);
+#endif
 
     bool fill(JsonObject *doc);
 
@@ -148,10 +152,17 @@ class BleFingerprint {
 
     static bool shouldHide(const String &s);
     uint8_t calculateTimeSlot(); // Calculate time slot (0-3) based on device ID
-    void fingerprint(NimBLEAdvertisedDevice *advertisedDevice);
-    void fingerprintServiceAdvertisements(NimBLEAdvertisedDevice *advertisedDevice, size_t serviceAdvCount, bool haveTxPower, int8_t txPower);
-    void fingerprintServiceData(NimBLEAdvertisedDevice *advertisedDevice, size_t serviceDataCount, bool haveTxPower, int8_t txPower);
-    void fingerprintManufactureData(NimBLEAdvertisedDevice *advertisedDevice, bool haveTxPower, int8_t txPower);
+#ifdef NIMBLE_V2
+    void fingerprint(const NimBLEAdvertisedDevice *advertisedDevice);
+    void fingerprintServiceAdvertisements(const NimBLEAdvertisedDevice *advertisedDevice, size_t serviceAdvCount, bool haveTxPower, int8_t txPower);
+    void fingerprintServiceData(const NimBLEAdvertisedDevice *advertisedDevice, size_t serviceDataCount, bool haveTxPower, int8_t txPower);
+    void fingerprintManufactureData(const NimBLEAdvertisedDevice *advertisedDevice, bool haveTxPower, int8_t txPower);
+#else
+    void fingerprint(BLEAdvertisedDevice *advertisedDevice);
+    void fingerprintServiceAdvertisements(BLEAdvertisedDevice *advertisedDevice, size_t serviceAdvCount, bool haveTxPower, int8_t txPower);
+    void fingerprintServiceData(BLEAdvertisedDevice *advertisedDevice, size_t serviceDataCount, bool haveTxPower, int8_t txPower);
+    void fingerprintManufactureData(BLEAdvertisedDevice *advertisedDevice, bool haveTxPower, int8_t txPower);
+#endif
 };
 
 #endif

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -7,8 +7,120 @@
 #include <algorithm>
 #include <cctype>
 #include <HeadlessWiFiSettings.h>
+#include <new>
 
 namespace BleFingerprintCollection {
+namespace {
+
+struct FingerprintSlot {
+    BleFingerprint *fingerprint = nullptr;
+    uint16_t refs = 0;
+    bool pendingDelete = false;
+};
+
+std::vector<FingerprintSlot> fingerprints;
+size_t activeFingerprints = 0;
+
+void finalizeSlot(FingerprintSlot &slot) {
+    if (!slot.pendingDelete || slot.refs != 0 || slot.fingerprint == nullptr)
+        return;
+
+    delete slot.fingerprint;
+    slot.fingerprint = nullptr;
+    slot.pendingDelete = false;
+}
+
+void removeSlot(size_t index, bool notify = true) {
+    auto &slot = fingerprints[index];
+    if (slot.fingerprint == nullptr || slot.pendingDelete)
+        return;
+
+    if (notify && onDel)
+        onDel(slot.fingerprint);
+
+    slot.pendingDelete = true;
+    if (activeFingerprints > 0)
+        --activeFingerprints;
+    finalizeSlot(slot);
+}
+
+size_t findEmptySlot() {
+    for (size_t i = 0; i < fingerprints.size(); ++i)
+        if (fingerprints[i].fingerprint == nullptr)
+            return i;
+    return static_cast<size_t>(-1);
+}
+
+size_t findEvictionSlot() {
+    size_t candidate = static_cast<size_t>(-1);
+    unsigned long oldestAge = 0;
+
+    for (size_t i = 0; i < fingerprints.size(); ++i) {
+        auto &slot = fingerprints[i];
+        if (slot.fingerprint == nullptr || slot.pendingDelete || slot.refs != 0)
+            continue;
+
+        auto age = slot.fingerprint->getMsSinceLastSeen();
+        if (candidate == static_cast<size_t>(-1) || age > oldestAge) {
+            candidate = i;
+            oldestAge = age;
+        }
+    }
+
+    return candidate;
+}
+
+size_t findAvailableSlot() {
+    auto empty = findEmptySlot();
+    if (empty != static_cast<size_t>(-1))
+        return empty;
+
+    auto eviction = findEvictionSlot();
+    if (eviction == static_cast<size_t>(-1))
+        return eviction;
+
+    removeSlot(eviction);
+    return fingerprints[eviction].fingerprint == nullptr ? eviction : static_cast<size_t>(-1);
+}
+
+void configureSlots(size_t capacity) {
+    if (!fingerprints.empty() && fingerprints.size() != capacity) {
+        log_w("Ignoring runtime max_fingerprints change from %u to %u; restart required",
+              static_cast<unsigned>(fingerprints.size()), static_cast<unsigned>(capacity));
+        return;
+    }
+
+    if (fingerprints.empty())
+        fingerprints.resize(capacity);
+}
+
+FingerprintLease acquireSlot(size_t index) {
+    auto &slot = fingerprints[index];
+    if (slot.fingerprint == nullptr || slot.pendingDelete)
+        return {};
+
+    ++slot.refs;
+    return {slot.fingerprint, index};
+}
+
+FingerprintLease findByAddress(const NimBLEAddress &mac) {
+    for (size_t i = fingerprints.size(); i-- > 0;) {
+        auto &slot = fingerprints[i];
+        if (slot.fingerprint != nullptr && !slot.pendingDelete && slot.fingerprint->getAddress() == mac)
+            return acquireSlot(i);
+    }
+    return {};
+}
+
+BleFingerprint *findById(const String &id) {
+    for (auto &slot : fingerprints)
+        if (slot.fingerprint != nullptr && !slot.pendingDelete && slot.fingerprint->getId() == id)
+            return slot.fingerprint;
+    return nullptr;
+}
+
+}  // namespace
+
 // Public (externed)
 String include{DEFAULT_INCLUDE},
        exclude{DEFAULT_EXCLUDE},
@@ -28,10 +140,10 @@ int8_t rxRefRssi = DEFAULT_RX_REF_RSSI,
 int forgetMs = DEFAULT_FORGET_MS,
     skipMs = DEFAULT_SKIP_MS,
     countMs = DEFAULT_COUNT_MS,
-    requeryMs = DEFAULT_REQUERY_MS;
+    requeryMs = DEFAULT_REQUERY_MS,
+    maxFingerprints = DEFAULT_MAX_FINGERPRINTS;
 std::vector<DeviceConfig> deviceConfigs;
 std::vector<uint8_t *> irks;
-std::vector<BleFingerprint *> fingerprints;
 TCallbackBool onSeen = nullptr;
 TCallbackFingerprint onAdd = nullptr;
 TCallbackFingerprint onDel = nullptr;
@@ -70,16 +182,15 @@ void Close(BleFingerprint *f, bool close) {
 
 #ifdef NIMBLE_V2
 void Seen(const NimBLEAdvertisedDevice *advertisedDevice) {
-    NimBLEAdvertisedDevice copy = *advertisedDevice;
 #else
 void Seen(BLEAdvertisedDevice *advertisedDevice) {
-    BLEAdvertisedDevice copy = *advertisedDevice;
 #endif
 
     if (onSeen) onSeen(true);
-    BleFingerprint *f = GetFingerprint(&copy);
-    if (f->seen(&copy) && onAdd)
-        onAdd(f);
+    auto lease = GetFingerprint(advertisedDevice);
+    if (lease && lease.fingerprint->seen(advertisedDevice) && onAdd)
+        onAdd(lease.fingerprint);
+    Release(lease);
     if (onSeen) onSeen(false);
 }
 
@@ -181,15 +292,19 @@ bool Config(String &id, String &json) {
 
     if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
         log_e("Couldn't take fingerprintMutex in Config!");
-    for (auto &it : fingerprints) {
-        auto it_id = it->getId();
+    for (auto &slot : fingerprints) {
+        if (slot.fingerprint == nullptr || slot.pendingDelete)
+            continue;
+
+        auto *fingerprint = slot.fingerprint;
+        auto it_id = fingerprint->getId();
         if (it_id == id || it_id == config.alias) {
-            it->setName(config.name);
-            it->setId(config.alias.length() > 0 ? config.alias : config.id, ID_TYPE_ALIAS, config.name);
+            fingerprint->setName(config.name);
+            fingerprint->setId(config.alias.length() > 0 ? config.alias : config.id, ID_TYPE_ALIAS, config.name);
             if (config.calRssi != NO_RSSI)
-                it->set1mRssi(config.calRssi);
+                fingerprint->set1mRssi(config.calRssi);
         } else
-            it->fingerprintAddress();
+            fingerprint->fingerprintAddress();
     }
     xSemaphoreGive(fingerprintMutex);
 
@@ -213,6 +328,7 @@ void ConnectToWifi() {
     maxDistance = HeadlessWiFiSettings.floating("max_dist", 0, 100, DEFAULT_MAX_DISTANCE, "Maximum distance to report (in meters)");
     skipDistance = HeadlessWiFiSettings.floating("skip_dist", 0, 10, DEFAULT_SKIP_DISTANCE, "Report early if beacon has moved more than this distance (in meters)");
     skipMs = HeadlessWiFiSettings.integer("skip_ms", 0, 3000000, DEFAULT_SKIP_MS, "Skip reporting if message age is less that this (in milliseconds)");
+    maxFingerprints = HeadlessWiFiSettings.integer("max_fingerprints", 16, 2048, DEFAULT_MAX_FINGERPRINTS, "Maximum BLE fingerprints to track");
 
     rxRefRssi = HeadlessWiFiSettings.integer("ref_rssi", -100, 100, DEFAULT_RX_REF_RSSI, "Rssi expected from a 0dBm transmitter at 1 meter (NOT used for iBeacons or Eddystone)");
     rxAdjRssi = HeadlessWiFiSettings.integer("rx_adj_rssi", -100, 100, DEFAULT_RX_ADJ_RSSI, "Rssi adjustment for receiver (use only if you know this device has a weak antenna)");
@@ -220,6 +336,7 @@ void ConnectToWifi() {
     forgetMs = HeadlessWiFiSettings.integer("forget_ms", 0, 3000000, DEFAULT_FORGET_MS, "Forget beacon if not seen for (in milliseconds)");
     txRefRssi = HeadlessWiFiSettings.integer("tx_ref_rssi", -100, 0, DEFAULT_TX_REF_RSSI, "Rssi expected from this tx power at 1m (used for node iBeacon)");
     maxDivisor = HeadlessWiFiSettings.integer("max_divisor", 2, 10, DEFAULT_MAX_DIVISOR, "Max divisor for reporting interval");
+    configureSlots(maxFingerprints);
 
     size_t start = 0;
     while (start < static_cast<size_t>(knownIrks.length())) {
@@ -304,17 +421,17 @@ void CleanupOldFingerprints() {
     auto now = millis();
     if (now - lastCleanup < 5000) return;
     lastCleanup = now;
-    auto it = fingerprints.begin();
     bool any = false;
-    while (it != fingerprints.end()) {
-        auto age = (*it)->getMsSinceLastSeen();
+    for (size_t i = 0; i < fingerprints.size(); ++i) {
+        auto &slot = fingerprints[i];
+        if (slot.fingerprint == nullptr || slot.pendingDelete)
+            continue;
+
+        auto age = slot.fingerprint->getMsSinceLastSeen();
         if (age > forgetMs) {
-            if (onDel) onDel((*it));
-            delete *it;
-            it = fingerprints.erase(it);
+            removeSlot(i);
         } else {
             any = true;
-            ++it;
         }
     }
     if (!any) {
@@ -336,37 +453,48 @@ void CleanupOldFingerprints() {
  * be expired depending on its ID type.
  *
  * @param advertisedDevice Advertised device used to identify or construct the fingerprint.
- * @return BleFingerprint* Pointer to the existing or newly created fingerprint stored in the collection.
+ * @return FingerprintLease Lease for the existing or newly created fingerprint stored in the collection.
  */
 #ifdef NIMBLE_V2
-BleFingerprint *getFingerprintInternal(const NimBLEAdvertisedDevice *advertisedDevice) {
+FingerprintLease getFingerprintInternal(const NimBLEAdvertisedDevice *advertisedDevice) {
 #else
-BleFingerprint *getFingerprintInternal(BLEAdvertisedDevice *advertisedDevice) {
+FingerprintLease getFingerprintInternal(BLEAdvertisedDevice *advertisedDevice) {
 #endif
-    auto mac = advertisedDevice->getAddress();
+    if (auto existing = findByAddress(advertisedDevice->getAddress()))
+        return existing;
 
-    auto it = std::find_if(fingerprints.rbegin(), fingerprints.rend(), [mac](BleFingerprint *f) { return f->getAddress() == mac; });
-    if (it != fingerprints.rend())
-        return *it;
+    CleanupOldFingerprints();
 
-    auto created = new BleFingerprint(advertisedDevice);
-    auto it2 = std::find_if(fingerprints.begin(), fingerprints.end(), [created](BleFingerprint *f) { return f->getId() == created->getId(); });
-    if (it2 != fingerprints.end()) {
-        auto found = *it2;
-        // Log.printf("Detected mac switch for fingerprint id %s\r\n", found->getId().c_str());
+    auto slotIndex = findAvailableSlot();
+    if (slotIndex == static_cast<size_t>(-1)) {
+        log_w("Dropping BLE fingerprint; max_fingerprints=%d is exhausted", maxFingerprints);
+        return {};
+    }
+
+    auto *created = new (std::nothrow) BleFingerprint(advertisedDevice);
+    if (created == nullptr) {
+        log_e("Failed to allocate fingerprint");
+        return {};
+    }
+
+    if (auto *found = findById(created->getId())) {
         created->setInitial(*found);
         if (found->getIdType() > ID_TYPE_UNIQUE)
             found->expire();
     }
 
-    fingerprints.push_back(created);
-    return created;
+    auto &slot = fingerprints[slotIndex];
+    slot.fingerprint = created;
+    slot.refs = 1;
+    slot.pendingDelete = false;
+    ++activeFingerprints;
+    return {created, slotIndex};
 }
 
 #ifdef NIMBLE_V2
-BleFingerprint *GetFingerprint(const NimBLEAdvertisedDevice *advertisedDevice) {
+FingerprintLease GetFingerprint(const NimBLEAdvertisedDevice *advertisedDevice) {
 #else
-BleFingerprint *GetFingerprint(BLEAdvertisedDevice *advertisedDevice) {
+FingerprintLease GetFingerprint(BLEAdvertisedDevice *advertisedDevice) {
 #endif
     if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
         log_e("Couldn't take semaphore!");
@@ -375,13 +503,49 @@ BleFingerprint *GetFingerprint(BLEAdvertisedDevice *advertisedDevice) {
     return f;
 }
 
-const std::vector<BleFingerprint *> GetCopy(bool cleanup) {
+FingerprintLease AcquireNext(size_t &cursor, bool cleanup) {
     if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
         log_e("Couldn't take fingerprintMutex!");
     if (cleanup) CleanupOldFingerprints();
-    std::vector<BleFingerprint *> copy(fingerprints);
+
+    while (cursor < fingerprints.size()) {
+        auto lease = acquireSlot(cursor++);
+        if (lease) {
+            xSemaphoreGive(fingerprintMutex);
+            return lease;
+        }
+    }
+
     xSemaphoreGive(fingerprintMutex);
-    return std::move(copy);
+    return {};
+}
+
+void Release(FingerprintLease &lease) {
+    if (!lease)
+        return;
+
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+        log_e("Couldn't take fingerprintMutex!");
+
+    if (lease.slot < fingerprints.size()) {
+        auto &slot = fingerprints[lease.slot];
+        if (slot.fingerprint == lease.fingerprint && slot.refs > 0) {
+            --slot.refs;
+            finalizeSlot(slot);
+        }
+    }
+
+    xSemaphoreGive(fingerprintMutex);
+    lease = {};
+}
+
+size_t Size(bool cleanup) {
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+        log_e("Couldn't take fingerprintMutex!");
+    if (cleanup) CleanupOldFingerprints();
+    auto count = activeFingerprints;
+    xSemaphoreGive(fingerprintMutex);
+    return count;
 }
 
 bool FindDeviceConfig(const String &id, DeviceConfig &config) {

--- a/src/BleFingerprintCollection.h
+++ b/src/BleFingerprintCollection.h
@@ -23,6 +23,16 @@ namespace BleFingerprintCollection {
 typedef std::function<void(bool)> TCallbackBool;
 typedef std::function<void(BleFingerprint *)> TCallbackFingerprint;
 
+struct FingerprintLease {
+    BleFingerprint *fingerprint = nullptr;
+    size_t slot = static_cast<size_t>(-1);
+
+    FingerprintLease() = default;
+    FingerprintLease(BleFingerprint *fingerprint, size_t slot) : fingerprint(fingerprint), slot(slot) {}
+
+    explicit operator bool() const { return fingerprint != nullptr; }
+};
+
 void Setup();
 void ConnectToWifi();
 bool Command(String &command, String &pay);
@@ -32,13 +42,15 @@ void Close(BleFingerprint *f, bool close);
 void Count(BleFingerprint *f, bool counting);
 #ifdef NIMBLE_V2
 void Seen(const NimBLEAdvertisedDevice *advertisedDevice);
-BleFingerprint *GetFingerprint(const NimBLEAdvertisedDevice *advertisedDevice);
+FingerprintLease GetFingerprint(const NimBLEAdvertisedDevice *advertisedDevice);
 #else
 void Seen(BLEAdvertisedDevice *advertisedDevice);
-BleFingerprint *GetFingerprint(BLEAdvertisedDevice *advertisedDevice);
+FingerprintLease GetFingerprint(BLEAdvertisedDevice *advertisedDevice);
 #endif
 void CleanupOldFingerprints();
-const std::vector<BleFingerprint *> GetCopy(bool cleanup = true);
+FingerprintLease AcquireNext(size_t &cursor, bool cleanup = true);
+void Release(FingerprintLease &lease);
+size_t Size(bool cleanup = true);
 bool FindDeviceConfig(const String &id, DeviceConfig &config);
 bool FindDeviceConfigByAlias(const String &alias, DeviceConfig &config);
 
@@ -53,8 +65,7 @@ extern TCallbackFingerprint onCountDel;
 extern String include, exclude, query, knownMacs, knownIrks, countIds;
 extern float skipDistance, maxDistance, absorption, countEnter, countExit;
 extern int8_t rxRefRssi, rxAdjRssi, txRefRssi, maxDivisor;
-extern int forgetMs, skipMs, countMs, requeryMs;
+extern int forgetMs, skipMs, countMs, requeryMs, maxFingerprints;
 extern std::vector<DeviceConfig> deviceConfigs;
 extern std::vector<uint8_t *> irks;
-extern std::vector<BleFingerprint *> fingerprints;
 }  // namespace BleFingerprintCollection

--- a/src/HttpWebServer.cpp
+++ b/src/HttpWebServer.cpp
@@ -36,16 +36,18 @@ void serializeConfigs(JsonObject &root) {
 void serializeDevices(JsonObject &root, bool showAll) {
     JsonArray devices = root.createNestedArray("devices");
 
-    auto f = BleFingerprintCollection::GetCopy();
-    for (auto it = f.begin(); it != f.end(); ++it) {
-        bool visible = (*it)->getVisible();
+    size_t cursor = 0;
+    while (auto lease = BleFingerprintCollection::AcquireNext(cursor)) {
+        auto *fingerprint = lease.fingerprint;
+        bool visible = fingerprint->getVisible();
         if (showAll || visible) {
             JsonObject node = devices.createNestedObject();
-            if ((*it)->fill(&node)) {
+            if (fingerprint->fill(&node)) {
                 if (showAll && visible) node[F("vis")] = true;
             } else
                 devices.remove(devices.size() - 1);
         }
+        BleFingerprintCollection::Release(lease);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -496,21 +496,26 @@ void reportLoop() {
     }
 
     yield();
-    auto copy = BleFingerprintCollection::GetCopy();
+    auto fingerprintCount = BleFingerprintCollection::Size();
 
     unsigned int count = 0;
-    for (auto &i : copy)
-        if (i->shouldCount())
+    size_t cursor = 0;
+    while (auto lease = BleFingerprintCollection::AcquireNext(cursor, false)) {
+        if (lease.fingerprint->shouldCount())
             count++;
+        BleFingerprintCollection::Release(lease);
+    }
 
     GUI::Count(count);
 
     yield();
-    sendTelemetry(totalSeen, totalFpSeen, totalFpQueried, totalFpReported, count, copy.size());
+    sendTelemetry(totalSeen, totalFpSeen, totalFpQueried, totalFpReported, count, fingerprintCount);
     yield();
 
     auto reported = 0;
-    for (auto &f : copy) {
+    cursor = 0;
+    while (auto lease = BleFingerprintCollection::AcquireNext(cursor, false)) {
+        auto *f = lease.fingerprint;
         auto seen = f->getSeenCount();
         if (seen) {
             totalSeen += seen;
@@ -525,6 +530,7 @@ void reportLoop() {
             totalFpReported++;
             reported++;
         }
+        BleFingerprintCollection::Release(lease);
         yield();
     }
 }
@@ -565,10 +571,12 @@ void scanTask(void *parameter) {
         log_e("Error starting continuous ble scan");
 
     while (true) {
-        auto queryable = BleFingerprintCollection::GetCopy(false);
-        for (auto &f : queryable)
-            if (f->query())
+        size_t cursor = 0;
+        while (auto lease = BleFingerprintCollection::AcquireNext(cursor, false)) {
+            if (lease.fingerprint->query())
                 totalFpQueried++;
+            BleFingerprintCollection::Release(lease);
+        }
 
         Enrollment::Loop();
 


### PR DESCRIPTION
## Summary
- replace snapshot-based fingerprint iteration with lease-based traversal over fixed slots
- bound BLE fingerprint storage with a configurable \ setting
- stop copying advertised devices and the IRK vector in hot BLE paths

## Testing
- pio run -e esp32
- pio run -e esp32c3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable fingerprint storage capacity with new configuration parameter (default: 256 fingerprints).
  * Added NimBLE v2 compatibility support alongside existing library support.

* **Refactor**
  * Improved fingerprint collection resource management through internal slot-based storage system for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->