### PR TITLE
fix: clean up stale UI build PRs

### DIFF
--- a/.github/workflows/ui-build-cleanup.yml
+++ b/.github/workflows/ui-build-cleanup.yml
@@ -1,0 +1,61 @@
+name: Cleanup stale UI build PRs
+
+on:
+  delete:
+
+jobs:
+  cleanup:
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+    - name: Close stale UI build PRs for deleted branch
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const deletedBranch = context.payload.ref;
+          const { owner, repo } = context.repo;
+          const uiBranch = `update-ui-build/${deletedBranch}`;
+
+          const prs = await github.paginate(github.rest.pulls.list, {
+            owner,
+            repo,
+            state: 'open',
+            per_page: 100
+          });
+
+          const matchingPrs = prs.filter(pr =>
+            pr.title === 'Update UI build outputs' &&
+            pr.user?.login === 'github-actions[bot]' &&
+            pr.head?.repo?.full_name === `${owner}/${repo}` &&
+            pr.head?.ref === uiBranch
+          );
+
+          core.info(`Found ${matchingPrs.length} UI build PR(s) for deleted branch ${deletedBranch}`);
+
+          for (const pr of matchingPrs) {
+            core.info(`Closing PR #${pr.number} (${pr.head.ref} -> ${pr.base.ref})`);
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: pr.number,
+              state: 'closed'
+            });
+          }
+
+          try {
+            await github.rest.git.deleteRef({
+              owner,
+              repo,
+              ref: `heads/${uiBranch}`
+            });
+            core.info(`Deleted branch ${uiBranch}`);
+          } catch (error) {
+            if (error.status === 404 || error.status === 422) {
+              core.info(`Branch ${uiBranch} already absent`);
+            } else {
+              throw error;
+            }
+          }

--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -44,6 +44,59 @@ jobs:
         git add src/ui_*.h
         echo "changes=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
 
+    - name: Close stale UI build PRs
+      if: |
+        steps.check_changes.outputs.changes > '0' &&
+        (github.event_name == 'push' ||
+         github.event.pull_request.head.repo.full_name == github.repository)
+      uses: actions/github-script@v8
+      env:
+        CURRENT_UI_PR_BRANCH: update-ui-build/${{ github.event.pull_request.head.ref || github.ref_name }}
+      with:
+        script: |
+          const currentBranch = process.env.CURRENT_UI_PR_BRANCH;
+          const { owner, repo } = context.repo;
+          const title = 'Update UI build outputs';
+
+          const prs = await github.paginate(github.rest.pulls.list, {
+            owner,
+            repo,
+            state: 'open',
+            per_page: 100
+          });
+
+          const stalePrs = prs.filter(pr =>
+            pr.title === title &&
+            pr.user?.login === 'github-actions[bot]' &&
+            pr.head?.repo?.full_name === `${owner}/${repo}` &&
+            pr.head?.ref?.startsWith('update-ui-build/') &&
+            pr.head.ref !== currentBranch
+          );
+
+          core.info(`Found ${stalePrs.length} stale UI build PR(s) to close`);
+
+          for (const pr of stalePrs) {
+            core.info(`Closing PR #${pr.number} (${pr.head.ref} -> ${pr.base.ref})`);
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: pr.number,
+              state: 'closed'
+            });
+
+            try {
+              await github.rest.git.deleteRef({
+                owner,
+                repo,
+                ref: `heads/${pr.head.ref}`
+              });
+            } catch (error) {
+              if (error.status !== 404 && error.status !== 422) {
+                throw error;
+              }
+            }
+          }
+
     - name: Create Pull Request
       if: |
         steps.check_changes.outputs.changes > '0' &&


### PR DESCRIPTION
## Summary
- close older bot-created `Update UI build outputs` PRs before opening a new one
- close stale UI build PRs when their target branch is deleted
- delete stale `update-ui-build/*` branches during cleanup when possible

## Testing
- parsed updated workflow YAML with `python3` + `yaml.safe_load`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated cleanup workflows to remove stale UI build pull requests and associated branch references when branches are deleted or during UI build operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->