### PR TITLE
fix: stabilize flaky hardware saving state test

### DIFF
--- a/ui/tests/hardware.spec.ts
+++ b/ui/tests/hardware.spec.ts
@@ -214,6 +214,16 @@ test.describe('Hardware Settings Page', () => {
 	});
 
 	test('should show saving state on submit button', async ({ page }) => {
+		// Delay POST response so the "Saving..." state is observable
+		await page.route('**/wifi/hardware', async (route) => {
+			if (route.request().method() === 'POST') {
+				await new Promise((r) => setTimeout(r, 500));
+				await route.fulfill({ status: 200 });
+			} else {
+				await route.fallback();
+			}
+		});
+
 		await page.goto('/hardware');
 		await page.waitForSelector('form#hardware');
 
@@ -222,10 +232,9 @@ test.describe('Hardware Settings Page', () => {
 		// Initial state
 		await expect(submitButton).toHaveText('Save');
 
-		// Click and quickly check for "Saving..." text
-		// Use Promise.all to catch the state change immediately
+		// Click and check for "Saving..." text
 		await Promise.all([
-			page.waitForSelector('button[type="submit"]:has-text("Saving...")'),
+			expect(submitButton).toHaveText('Saving...', { timeout: 5000 }),
 			submitButton.click()
 		]);
 

--- a/ui/tests/hardware.spec.ts
+++ b/ui/tests/hardware.spec.ts
@@ -214,10 +214,15 @@ test.describe('Hardware Settings Page', () => {
 	});
 
 	test('should show saving state on submit button', async ({ page }) => {
-		// Delay POST response so the "Saving..." state is observable
+		// Gate that holds the POST response until we release it
+		let releasePost!: () => void;
+		const postGate = new Promise<void>((resolve) => {
+			releasePost = resolve;
+		});
+
 		await page.route('**/wifi/hardware', async (route) => {
 			if (route.request().method() === 'POST') {
-				await new Promise((r) => setTimeout(r, 500));
+				await postGate;
 				await route.fulfill({ status: 200 });
 			} else {
 				await route.fallback();
@@ -232,11 +237,13 @@ test.describe('Hardware Settings Page', () => {
 		// Initial state
 		await expect(submitButton).toHaveText('Save');
 
-		// Click and check for "Saving..." text
-		await Promise.all([
-			expect(submitButton).toHaveText('Saving...', { timeout: 5000 }),
-			submitButton.click()
-		]);
+		// Click, then assert "Saving..." while POST is held open
+		const clickPromise = submitButton.click();
+		await expect(submitButton).toHaveText('Saving...', { timeout: 5000 });
+
+		// Release the POST response
+		releasePost();
+		await clickPromise;
 
 		// Eventually returns to normal state
 		await expect(submitButton).toHaveText('Save', { timeout: 10000 });


### PR DESCRIPTION
## Summary
- Fix flaky `should show saving state on submit button` test in `hardware.spec.ts`
- The mock POST response was instant, so the "Saving..." button state was too transient to observe reliably
- Added a 500ms delay to the POST mock in this test so the intermediate state is always visible
- Switched from `page.waitForSelector` to Playwright's `expect().toHaveText()` for better retry semantics

## Test plan
- [x] All 14 hardware tests pass locally
- [ ] CI ui-tests job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for the hardware settings form submit flow by gating the network response and explicitly asserting the submit button shows "Saving..." during the pending request, then verifying it returns to "Save" after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->