### PR TITLE
Complete the work for adding wESP32 Rev7+ (Ethernet) board support

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -123,11 +123,19 @@
 #define DEFAULT_I2C_BUS_2_SCL -1
 #define DEFAULT_I2C_BUS 1
 #else
+#ifdef WESP32_REV7_PLUS
+#define DEFAULT_I2C_BUS_1_SDA 15
+#define DEFAULT_I2C_BUS_1_SCL 4
+#define DEFAULT_I2C_BUS_2_SDA 33
+#define DEFAULT_I2C_BUS_2_SCL 5
+#define DEFAULT_I2C_BUS 1
+#else
 #define DEFAULT_I2C_BUS_1_SDA 21
 #define DEFAULT_I2C_BUS_1_SCL 22
 #define DEFAULT_I2C_BUS_2_SDA -1
 #define DEFAULT_I2C_BUS_2_SCL -1
 #define DEFAULT_I2C_BUS 1
+#endif
 #endif
 #endif
 #endif
@@ -171,6 +179,15 @@
 #define DEFAULT_LED1_CNT 1
 
 #define MAX_BRIGHTNESS 20
+
+#elif defined WESP32_REV7_PLUS
+
+#define DEFAULT_LED1_TYPE 2
+#define DEFAULT_LED1_PIN -1
+#define DEFAULT_LED1_CNTRL Control_Type_Status
+#define DEFAULT_LED1_CNT 1
+
+#define MAX_BRIGHTNESS 100
 
 #else  // DevKit / generic
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -376,3 +376,17 @@ build_flags =
   -D FIRMWARE='"macchina-a0"'
   -D SENSORS
   ${esp32.build_flags}
+
+[env:wesp32-r7-plus]
+extends = esp32
+board = wesp32
+lib_deps =
+  ${esp32.lib_deps}
+  ${sensors.lib_deps}
+build_flags =
+  -D CORE_DEBUG_LEVEL=1
+  -D WESP32_REV7_PLUS
+  -D FIRMWARE='"wesp32-r7-plus"'
+  -D SENSORS
+  ${esp32.build_flags}
+board_build.flash_size = 16MB

--- a/ui/src/routes/network/+page.svelte
+++ b/ui/src/routes/network/+page.svelte
@@ -187,6 +187,7 @@
                     <option value="10">EST-PoE-32</option>
                     <option value="11">LilyGO-T-ETH-Lite (RTL8201)</option>
                     <option value="12">ESP32-POE_A1</option>
+                    <option value="13">wESP32 Rev7+ (RTL8201)</option>
                 </select>
             </div>
 


### PR DESCRIPTION
Adds I2C pin defaults (SDA1: 15, SCL1: 4, SDA2: 33, SCL2: 5). I found that the board upgrade caused boot loops when using the I2C interface without setting these

PlatformIO environment configuration to allow the pin defaults

Re-adds the UI dropdown entry for board selection which got messed up in #2005 and #2041 
     
Tested on wESP32 Rev7+ hardware with 16MB flash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new hardware device variant with dedicated configuration for network connectivity and hardware peripherals.
  * New selectable Ethernet device option available in network settings for enhanced network interface configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->