### PR TITLE
feat: add tiered memory ColdTier pre-filter for device-dense environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ src/build_timestamp_value.h
 playwright-report
 test-results
 .omc/
+compile_commands.json

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -83,7 +83,10 @@
 #endif
 #ifndef DEFAULT_MAX_COLD
 #if defined(BOARD_HAS_PSRAM)
-#define DEFAULT_MAX_COLD 256
+// PSRAM: fleet runs 1024 (24 KB) stably; larger cold tier gives random-MAC
+// advertisers room to accumulate sightings before eviction. 256 was a
+// regression vs previously-deployed values on the same hardware.
+#define DEFAULT_MAX_COLD 1024
 #elif defined(ESP32S3)
 #define DEFAULT_MAX_COLD 128
 #elif defined(ESP32C3) || defined(ESP32C6)

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -75,6 +75,33 @@
 #define DEFAULT_MAX_FINGERPRINTS 100
 #endif
 
+// Tiered memory (ColdTier pre-filter) — sized per-chip based on available
+// memory. PSRAM-equipped boards (WROVER, S3-N8R8) can hold a much larger
+// ColdTier cheaply; internal-SRAM-only boards stay conservative.
+#ifndef DEFAULT_TIERED_MEMORY_ENABLED
+#define DEFAULT_TIERED_MEMORY_ENABLED 1
+#endif
+#ifndef DEFAULT_MAX_COLD
+#if defined(BOARD_HAS_PSRAM)
+#define DEFAULT_MAX_COLD 256
+#elif defined(ESP32S3)
+#define DEFAULT_MAX_COLD 128
+#elif defined(ESP32C3) || defined(ESP32C6)
+#define DEFAULT_MAX_COLD 64
+#else
+#define DEFAULT_MAX_COLD 128
+#endif
+#endif
+#ifndef DEFAULT_COLD_MIN_RSSI
+#define DEFAULT_COLD_MIN_RSSI -90
+#endif
+#ifndef DEFAULT_COLD_PROMOTION_COUNT
+#define DEFAULT_COLD_PROMOTION_COUNT 5
+#endif
+#ifndef DEFAULT_COLD_PROMOTION_RSSI
+#define DEFAULT_COLD_PROMOTION_RSSI -75
+#endif
+
 // RX_ADJ_RSSI Defaults
 #ifdef M5STICK
 #define DEFAULT_RX_ADJ_RSSI 0

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -85,7 +85,10 @@
 #endif
 #ifndef DEFAULT_MAX_COLD
 #if defined(BOARD_HAS_PSRAM)
-#define DEFAULT_MAX_COLD 256
+// PSRAM: fleet runs 1024 (24 KB) stably; larger cold tier gives random-MAC
+// advertisers room to accumulate sightings before eviction. 256 was a
+// regression vs previously-deployed values on the same hardware.
+#define DEFAULT_MAX_COLD 1024
 #elif defined(ESP32S3)
 #define DEFAULT_MAX_COLD 128
 #elif defined(ESP32C3) || defined(ESP32C6)

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -77,6 +77,33 @@
 #define DEFAULT_MAX_FINGERPRINTS 45
 #endif
 
+// Tiered memory (ColdTier pre-filter) — sized per-chip based on available
+// memory. PSRAM-equipped boards (WROVER, S3-N8R8) can hold a much larger
+// ColdTier cheaply; internal-SRAM-only boards stay conservative.
+#ifndef DEFAULT_TIERED_MEMORY_ENABLED
+#define DEFAULT_TIERED_MEMORY_ENABLED 1
+#endif
+#ifndef DEFAULT_MAX_COLD
+#if defined(BOARD_HAS_PSRAM)
+#define DEFAULT_MAX_COLD 256
+#elif defined(ESP32S3)
+#define DEFAULT_MAX_COLD 128
+#elif defined(ESP32C3) || defined(ESP32C6)
+#define DEFAULT_MAX_COLD 64
+#else
+#define DEFAULT_MAX_COLD 128
+#endif
+#endif
+#ifndef DEFAULT_COLD_MIN_RSSI
+#define DEFAULT_COLD_MIN_RSSI -90
+#endif
+#ifndef DEFAULT_COLD_PROMOTION_COUNT
+#define DEFAULT_COLD_PROMOTION_COUNT 5
+#endif
+#ifndef DEFAULT_COLD_PROMOTION_RSSI
+#define DEFAULT_COLD_PROMOTION_RSSI -75
+#endif
+
 // RX_ADJ_RSSI Defaults
 #ifdef M5STICK
 #define DEFAULT_RX_ADJ_RSSI 0

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -103,9 +103,9 @@
 #ifndef DEFAULT_COLD_PROMOTION_COUNT
 #define DEFAULT_COLD_PROMOTION_COUNT 5
 #endif
-#ifndef DEFAULT_COLD_PROMOTION_RSSI
-#define DEFAULT_COLD_PROMOTION_RSSI -75
-#endif
+// No promotion RSSI floor by design — see the promotion comment in
+// BleFingerprintCollection::Seen(). Gating promotion on signal strength starves
+// multilateration of the distant nodes it needs to solve a position.
 
 // RX_ADJ_RSSI Defaults
 #ifdef M5STICK

--- a/platformio.ini
+++ b/platformio.ini
@@ -197,6 +197,24 @@ build_flags =
   -D SENSORS
   ${esp32.build_flags}
 
+; WROVER-class ESP32 with PSRAM. The deployed fleet reports firm=esp32-wrover,
+; so preserve that name for OTA URL compatibility. BOARD_HAS_PSRAM unlocks
+; DEFAULT_MAX_COLD=256 and enables ESP-IDF's external SPIRAM mapping so
+; heap_caps_malloc(MALLOC_CAP_SPIRAM) actually returns PSRAM-backed memory.
+[env:esp32-wrover]
+extends = esp32
+board = esp-wrover-kit
+lib_deps =
+  ${esp32.lib_deps}
+  ${sensors.lib_deps}
+build_flags =
+  -D CORE_DEBUG_LEVEL=1
+  -D FIRMWARE='"esp32-wrover"'
+  -D SENSORS
+  -D BOARD_HAS_PSRAM
+  -mfix-esp32-psram-cache-issue
+  ${esp32.build_flags}
+
 [env:esp32c3]
 extends = esp32c3
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -376,3 +376,12 @@ build_flags =
   -D FIRMWARE='"macchina-a0"'
   -D SENSORS
   ${esp32.build_flags}
+
+[env:native-memory]
+platform = native
+build_flags =
+  -std=gnu++17
+  -DUNIT_TEST
+  -I src
+  -I include
+test_filter = test_memory_tier

--- a/platformio.ini
+++ b/platformio.ini
@@ -199,6 +199,24 @@ build_flags =
   -D SENSORS
   ${esp32.build_flags}
 
+; WROVER-class ESP32 with PSRAM. The deployed fleet reports firm=esp32-wrover,
+; so preserve that name for OTA URL compatibility. BOARD_HAS_PSRAM unlocks
+; DEFAULT_MAX_COLD=256 and enables ESP-IDF's external SPIRAM mapping so
+; heap_caps_malloc(MALLOC_CAP_SPIRAM) actually returns PSRAM-backed memory.
+[env:esp32-wrover]
+extends = esp32
+board = esp-wrover-kit
+lib_deps =
+  ${esp32.lib_deps}
+  ${sensors.lib_deps}
+build_flags =
+  -D CORE_DEBUG_LEVEL=1
+  -D FIRMWARE='"esp32-wrover"'
+  -D SENSORS
+  -D BOARD_HAS_PSRAM
+  -mfix-esp32-psram-cache-issue
+  ${esp32.build_flags}
+
 [env:esp32c3]
 extends = esp32c3
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -387,3 +387,12 @@ test_framework = unity
 lib_compat_mode = off
 lib_deps = bblanchon/ArduinoJson@^6.21.5
 build_flags = -std=gnu++17 -Wall -Wextra
+
+[env:native-memory]
+platform = native
+build_flags =
+  -std=gnu++17
+  -DUNIT_TEST
+  -I src
+  -I include
+test_filter = test_memory_tier

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -1,10 +1,12 @@
 #include "BleFingerprintCollection.h"
 
+#include "BleMemoryTier.h"
 #include "defaults.h"
 #include "mqtt.h"
 #include "Logger.h"
 #include <Arduino.h>
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <HeadlessWiFiSettings.h>
 #include <new>
@@ -160,9 +162,47 @@ unsigned long lastCleanup = 0;
 SemaphoreHandle_t fingerprintMutex;
 SemaphoreHandle_t deviceConfigMutex;
 
+// --- Tiered memory pre-filter (ColdTier) ------------------------------------
+// Drops noise (weak RSSI, transient random MACs) BEFORE a live fingerprint slot
+// is allocated. Sits on top of the slot pool from PR #2208 — does not replace
+// it. Single TieredMemoryManager instance; ColdTier internal storage prefers
+// PSRAM with fallback to internal SRAM.
+TieredMemoryConfig tieredMemoryConfig;
+TieredMemoryManager *tieredMemory = nullptr;
+SemaphoreHandle_t coldMutex;
+
+std::atomic<uint32_t> tierDropCount{0};
+std::atomic<uint32_t> tierColdCount{0};
+std::atomic<uint32_t> tierHotCount{0};
+std::atomic<uint32_t> tierPromoteCount{0};
+
+bool tieredMemoryReady() {
+    return tieredMemory != nullptr && tieredMemory->config().enabled && tieredMemory->coldTier().isEnabled();
+}
+
 void Setup() {
     fingerprintMutex = xSemaphoreCreateMutex();
     deviceConfigMutex = xSemaphoreCreateMutex();
+    coldMutex = xSemaphoreCreateMutex();
+
+    tieredMemoryConfig.enabled = DEFAULT_TIERED_MEMORY_ENABLED != 0;
+    tieredMemoryConfig.maxCold = DEFAULT_MAX_COLD;
+    tieredMemoryConfig.minRssi = DEFAULT_COLD_MIN_RSSI;
+
+    tieredMemory = new (std::nothrow) TieredMemoryManager(tieredMemoryConfig);
+    if (tieredMemory == nullptr) {
+        log_w("TieredMemoryManager allocation failed; tiered pre-filter disabled");
+    } else if (!tieredMemory->coldTier().isEnabled()) {
+        log_w("ColdTier backing allocation failed; tiered pre-filter disabled (will pass everything HOT)");
+    } else {
+        log_i("ColdTier: %u records @ %s (%u bytes), minRssi=%d, promote>=%d sightings w/ rssi>%d",
+              (unsigned)tieredMemory->coldTier().capacity(),
+              tieredMemory->coldTier().isUsingPsram() ? "PSRAM" : "internal SRAM",
+              (unsigned)(tieredMemory->coldTier().capacity() * sizeof(ColdRecord)),
+              (int)tieredMemoryConfig.minRssi,
+              DEFAULT_COLD_PROMOTION_COUNT,
+              DEFAULT_COLD_PROMOTION_RSSI);
+    }
 }
 
 void Count(BleFingerprint *f, bool counting) {
@@ -188,12 +228,75 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
 #endif
 
     if (onSeen) onSeen(true);
+
+    // ColdTier pre-filter: drop / defer BEFORE taking the slot-pool mutex and
+    // allocating a BleFingerprint. Shrinks mutex contention and keeps hot slots
+    // for devices that actually matter. When the tier is disabled (alloc
+    // failure or explicitly off) classify() returns HOT for everything and we
+    // fall through to the original behaviour.
+    if (tieredMemoryReady()) {
+        const int8_t rssi = static_cast<int8_t>(advertisedDevice->getRSSI());
+#ifdef NIMBLE_V2
+        const uint8_t *mac = advertisedDevice->getAddress().getVal();
+#else
+        const uint8_t *mac = advertisedDevice->getAddress().getNative();
+#endif
+        // advData is only read by classify() for iBeacon detection; skipping it
+        // means iBeacons take the cold-then-promote path instead of jumping
+        // straight to HOT — a minor optimisation we can add later if it matters.
+        ClassifyResult result = tieredMemory->classify(mac, nullptr, 0, rssi);
+
+        if (result == ClassifyResult::DROP) {
+            tierDropCount.fetch_add(1, std::memory_order_relaxed);
+            if (onSeen) onSeen(false);
+            return;  // no slot-pool mutex, no heap allocation
+        }
+
+        if (result == ClassifyResult::COLD) {
+            bool shouldPromote = false;
+            if (xSemaphoreTake(coldMutex, MAX_WAIT) == pdTRUE) {
+                const uint32_t nowMs = millis();
+                ColdTier &cold = tieredMemory->coldTier();
+                cold.insert(mac, rssi, nowMs);  // create-or-update; increments seenCount
+                if (ColdRecord *rec = cold.lookup(mac)) {
+                    if (rec->seenCount >= DEFAULT_COLD_PROMOTION_COUNT &&
+                        rssi > DEFAULT_COLD_PROMOTION_RSSI) {
+                        shouldPromote = true;
+                        cold.remove(mac);  // leaving cold — avoid double-tracking
+                    }
+                }
+                xSemaphoreGive(coldMutex);
+            } else {
+                log_e("Couldn't take coldMutex in Seen");
+            }
+
+            if (!shouldPromote) {
+                tierColdCount.fetch_add(1, std::memory_order_relaxed);
+                if (onSeen) onSeen(false);
+                return;
+            }
+            tierPromoteCount.fetch_add(1, std::memory_order_relaxed);
+            // fall through to HOT path
+        }
+
+        tierHotCount.fetch_add(1, std::memory_order_relaxed);
+    }
+
     auto lease = GetFingerprint(advertisedDevice);
     if (lease && lease.fingerprint->seen(advertisedDevice) && onAdd)
         onAdd(lease.fingerprint);
     Release(lease);
     if (onSeen) onSeen(false);
 }
+
+uint32_t getTierDropCount() { return tierDropCount.load(std::memory_order_relaxed); }
+uint32_t getTierColdCount() { return tierColdCount.load(std::memory_order_relaxed); }
+uint32_t getTierHotCount() { return tierHotCount.load(std::memory_order_relaxed); }
+uint32_t getTierPromoteCount() { return tierPromoteCount.load(std::memory_order_relaxed); }
+size_t getColdTierCapacity() { return tieredMemory ? tieredMemory->coldTier().capacity() : 0; }
+size_t getColdTierCount() { return tieredMemory ? tieredMemory->coldTier().count() : 0; }
+bool isColdTierUsingPsram() { return tieredMemory && tieredMemory->coldTier().isUsingPsram(); }
+bool isTieredMemoryEnabled() { return tieredMemoryReady(); }
 
 /**
  * @brief Add a device configuration or replace an existing one with the same id.

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -262,7 +262,8 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
         const uint8_t *advData = advertisedDevice->getPayload();
         const size_t advLen = advertisedDevice->getPayloadLength();
 #endif
-        ClassifyResult result = tieredMemory->classify(mac, advData, advLen, rssi);
+        uint8_t idType = ID_TYPE_MISC;
+        ClassifyResult result = tieredMemory->classify(mac, advData, advLen, rssi, &idType);
 
         if (result == ClassifyResult::DROP) {
             tierDropCount.fetch_add(1, std::memory_order_relaxed);
@@ -275,7 +276,10 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
             if (xSemaphoreTake(coldMutex, MAX_WAIT) == pdTRUE) {
                 const uint32_t nowMs = millis();
                 ColdTier &cold = tieredMemory->coldTier();
-                cold.insert(mac, rssi, nowMs);  // create-or-update; increments seenCount
+                // Pass idType so eviction bonuses (iBeacon +50, known-MAC +100)
+                // actually get applied — without this, idType stays ID_TYPE_MISC
+                // and EvictionScorer's bonuses are dead code.
+                cold.insert(mac, rssi, nowMs, idType);  // create-or-update; increments seenCount
                 if (ColdRecord *rec = cold.lookup(mac)) {
                     if (rec->seenCount >= DEFAULT_COLD_PROMOTION_COUNT &&
                         rssi > DEFAULT_COLD_PROMOTION_RSSI) {

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -326,8 +326,10 @@ bool isTieredMemoryEnabled() { return tieredMemoryReady(); }
  * @return true if a new configuration was added, false if an existing configuration was replaced.
  */
 bool addOrReplace(DeviceConfig config) {
-    if (xSemaphoreTake(deviceConfigMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(deviceConfigMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take deviceConfigMutex in addOrReplace!");
+        return false;
+    }
 
     std::vector<String> idsToDelete;
     bool isReplacement = false;
@@ -414,8 +416,10 @@ bool Config(String &id, String &json) {
         }
     }
 
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take fingerprintMutex in Config!");
+        return false;
+    }
     for (auto &slot : fingerprints) {
         if (slot.fingerprint == nullptr || slot.pendingDelete)
             continue;
@@ -625,16 +629,20 @@ FingerprintLease GetFingerprint(const NimBLEAdvertisedDevice *advertisedDevice) 
 #else
 FingerprintLease GetFingerprint(BLEAdvertisedDevice *advertisedDevice) {
 #endif
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take semaphore!");
+        return {};
+    }
     auto f = getFingerprintInternal(advertisedDevice);
     xSemaphoreGive(fingerprintMutex);
     return f;
 }
 
 FingerprintLease AcquireNext(size_t &cursor, bool cleanup) {
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take fingerprintMutex!");
+        return {};
+    }
     if (cleanup) CleanupOldFingerprints();
 
     while (cursor < fingerprints.size()) {
@@ -653,8 +661,13 @@ void Release(FingerprintLease &lease) {
     if (!lease)
         return;
 
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take fingerprintMutex!");
+        // Leak the lease rather than touch shared state without the mutex —
+        // the slot's refs stays elevated so the fingerprint isn't freed
+        // from under another reader; acceptable trade-off vs corruption.
+        return;
+    }
 
     if (lease.slot < fingerprints.size()) {
         auto &slot = fingerprints[lease.slot];
@@ -669,8 +682,10 @@ void Release(FingerprintLease &lease) {
 }
 
 size_t Size(bool cleanup) {
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take fingerprintMutex!");
+        return 0;
+    }
     if (cleanup) CleanupOldFingerprints();
     auto count = activeFingerprints;
     xSemaphoreGive(fingerprintMutex);

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -234,13 +234,21 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
     // for devices that actually matter. When the tier is disabled (alloc
     // failure or explicitly off) classify() returns HOT for everything and we
     // fall through to the original behaviour.
-    if (tieredMemoryReady()) {
+    if (tieredMemoryReady() && coldMutex != nullptr) {
         const int8_t rssi = static_cast<int8_t>(advertisedDevice->getRSSI());
+        // NimBLEAdvertisedDevice::getAddress() returns NimBLEAddress by VALUE;
+        // taking a pointer into the temporary via getVal()/getNative() in a
+        // single expression is UB — the temporary dies at the `;`. Copy the
+        // six bytes into a stack buffer that outlives every downstream call.
+        uint8_t mac[6];
+        {
+            const auto addr = advertisedDevice->getAddress();
 #ifdef NIMBLE_V2
-        const uint8_t *mac = advertisedDevice->getAddress().getVal();
+            memcpy(mac, addr.getVal(), 6);
 #else
-        const uint8_t *mac = advertisedDevice->getAddress().getNative();
+            memcpy(mac, addr.getNative(), 6);
 #endif
+        }
         // advData is only read by classify() for iBeacon detection; skipping it
         // means iBeacons take the cold-then-promote path instead of jumping
         // straight to HOT — a minor optimisation we can add later if it matters.

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -249,10 +249,20 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
             memcpy(mac, addr.getNative(), 6);
 #endif
         }
-        // advData is only read by classify() for iBeacon detection; skipping it
-        // means iBeacons take the cold-then-promote path instead of jumping
-        // straight to HOT — a minor optimisation we can add later if it matters.
-        ClassifyResult result = tieredMemory->classify(mac, nullptr, 0, rssi);
+        // Pass the raw advertisement payload so classify()'s isIBeacon() check
+        // can fire — iBeacons (02 15 prefix) go straight to HOT instead of
+        // taking the cold-then-promote path. Important for presence tracking:
+        // most deployed beacons are iBeacons and we don't want 5 sightings of
+        // latency before they show up.
+#ifdef NIMBLE_V2
+        const auto payload = advertisedDevice->getPayload();
+        const uint8_t *advData = payload.data();
+        const size_t advLen = payload.size();
+#else
+        const uint8_t *advData = advertisedDevice->getPayload();
+        const size_t advLen = advertisedDevice->getPayloadLength();
+#endif
+        ClassifyResult result = tieredMemory->classify(mac, advData, advLen, rssi);
 
         if (result == ClassifyResult::DROP) {
             tierDropCount.fetch_add(1, std::memory_order_relaxed);

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -218,13 +218,12 @@ void Setup() {
     } else if (!tieredMemory->coldTier().isEnabled()) {
         log_w("ColdTier backing allocation failed; tiered pre-filter disabled (will pass everything HOT)");
     } else {
-        log_i("ColdTier: %u records @ %s (%u bytes), minRssi=%d, promote>=%d sightings w/ rssi>%d",
+        log_i("ColdTier: %u records @ %s (%u bytes), minRssi=%d, promote>=%d sightings",
               (unsigned)tieredMemory->coldTier().capacity(),
               tieredMemory->coldTier().isUsingPsram() ? "PSRAM" : "internal SRAM",
               (unsigned)(tieredMemory->coldTier().capacity() * sizeof(ColdRecord)),
               (int)tieredMemoryConfig.minRssi,
-              DEFAULT_COLD_PROMOTION_COUNT,
-              DEFAULT_COLD_PROMOTION_RSSI);
+              DEFAULT_COLD_PROMOTION_COUNT);
     }
 }
 
@@ -304,8 +303,17 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
                 // and EvictionScorer's bonuses are dead code.
                 cold.insert(mac, rssi, nowMs, idType);  // create-or-update; increments seenCount
                 if (ColdRecord *rec = cold.lookup(mac)) {
-                    if (rec->seenCount >= DEFAULT_COLD_PROMOTION_COUNT &&
-                        rssi > DEFAULT_COLD_PROMOTION_RSSI) {
+                    // Promotion is sighting-count driven ONLY. Do not gate on RSSI
+                    // here: ESPresense is a multilateration system, and a fix needs
+                    // three or more nodes reporting the same device. The distant
+                    // nodes — the ones supplying the geometric spread that makes a
+                    // solution possible — are precisely the ones reading weak. An
+                    // RSSI floor on promotion silences them, so devices collapse to
+                    // a single reporting node and never resolve to a position.
+                    // The -90 dBm DROP floor in QuickClassifier is the only signal
+                    // strength filter; below that a reading is too noisy to invert
+                    // into a distance anyway.
+                    if (rec->seenCount >= DEFAULT_COLD_PROMOTION_COUNT) {
                         shouldPromote = true;
                         cold.remove(mac);  // leaving cold — avoid double-tracking
                     }
@@ -522,6 +530,39 @@ void ConnectToWifi(bool updating) {
             continue;
         }
         irks.push_back(irk);
+    }
+
+    // Register configured known MACs with the ColdTier pre-filter so they skip the
+    // cold-then-promote warmup and take a live slot on first sighting. Without this
+    // QuickClassifier::isKnownMac() never matched anything — the table was allocated
+    // and then left empty — so known_macs got no protection from the pre-filter at all.
+    //
+    // ponytail: exact 6-byte match only. BleFingerprint::fingerprintAddress() uses
+    // prefixExists(), so a shorter prefix entry (e.g. an OUI) is still honoured for
+    // naming but does not register here; it just takes the normal sighting-count
+    // warmup instead of jumping straight to HOT. Build a prefix table only if someone
+    // actually relies on OUI-wide known_macs.
+    if (tieredMemoryReady()) {
+        start = 0;
+        while (start < static_cast<size_t>(knownMacs.length())) {
+            while (start < static_cast<size_t>(knownMacs.length()) && std::isspace(static_cast<unsigned char>(knownMacs[start])))
+                ++start;
+            if (start >= static_cast<size_t>(knownMacs.length()))
+                break;
+
+            size_t end = start;
+            while (end < static_cast<size_t>(knownMacs.length()) && !std::isspace(static_cast<unsigned char>(knownMacs[end])))
+                ++end;
+
+            auto mac_hex = knownMacs.substring(start, end);
+            start = end;
+            if (mac_hex.length() != 12)  // prefix entry, not a full MAC
+                continue;
+
+            uint8_t mac[6];
+            if (hextostr(mac_hex, mac, 6))
+                tieredMemory->classifier().addKnownMac(mac);
+        }
     }
 }
 

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -1,10 +1,12 @@
 #include "BleFingerprintCollection.h"
 
+#include "BleMemoryTier.h"
 #include "defaults.h"
 #include "mqtt.h"
 #include "Logger.h"
 #include <Arduino.h>
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <HeadlessWiFiSettings.h>
 #include <new>
@@ -183,9 +185,47 @@ struct FingerprintLock {
     explicit operator bool() const { return ok; }
 };
 
+// --- Tiered memory pre-filter (ColdTier) ------------------------------------
+// Drops noise (weak RSSI, transient random MACs) BEFORE a live fingerprint slot
+// is allocated. Sits on top of the slot pool from PR #2208 — does not replace
+// it. Single TieredMemoryManager instance; ColdTier internal storage prefers
+// PSRAM with fallback to internal SRAM.
+TieredMemoryConfig tieredMemoryConfig;
+TieredMemoryManager *tieredMemory = nullptr;
+SemaphoreHandle_t coldMutex;
+
+std::atomic<uint32_t> tierDropCount{0};
+std::atomic<uint32_t> tierColdCount{0};
+std::atomic<uint32_t> tierHotCount{0};
+std::atomic<uint32_t> tierPromoteCount{0};
+
+bool tieredMemoryReady() {
+    return tieredMemory != nullptr && tieredMemory->config().enabled && tieredMemory->coldTier().isEnabled();
+}
+
 void Setup() {
     fingerprintMutex = xSemaphoreCreateMutex();
     deviceConfigMutex = xSemaphoreCreateMutex();
+    coldMutex = xSemaphoreCreateMutex();
+
+    tieredMemoryConfig.enabled = DEFAULT_TIERED_MEMORY_ENABLED != 0;
+    tieredMemoryConfig.maxCold = DEFAULT_MAX_COLD;
+    tieredMemoryConfig.minRssi = DEFAULT_COLD_MIN_RSSI;
+
+    tieredMemory = new (std::nothrow) TieredMemoryManager(tieredMemoryConfig);
+    if (tieredMemory == nullptr) {
+        log_w("TieredMemoryManager allocation failed; tiered pre-filter disabled");
+    } else if (!tieredMemory->coldTier().isEnabled()) {
+        log_w("ColdTier backing allocation failed; tiered pre-filter disabled (will pass everything HOT)");
+    } else {
+        log_i("ColdTier: %u records @ %s (%u bytes), minRssi=%d, promote>=%d sightings w/ rssi>%d",
+              (unsigned)tieredMemory->coldTier().capacity(),
+              tieredMemory->coldTier().isUsingPsram() ? "PSRAM" : "internal SRAM",
+              (unsigned)(tieredMemory->coldTier().capacity() * sizeof(ColdRecord)),
+              (int)tieredMemoryConfig.minRssi,
+              DEFAULT_COLD_PROMOTION_COUNT,
+              DEFAULT_COLD_PROMOTION_RSSI);
+    }
 }
 
 void Count(BleFingerprint *f, bool counting) {
@@ -211,6 +251,60 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
 #endif
 
     if (onSeen) onSeen(true);
+
+    // ColdTier pre-filter: drop / defer BEFORE taking the slot-pool mutex and
+    // allocating a BleFingerprint. Shrinks mutex contention and keeps hot slots
+    // for devices that actually matter. When the tier is disabled (alloc
+    // failure or explicitly off) classify() returns HOT for everything and we
+    // fall through to the original behaviour.
+    if (tieredMemoryReady()) {
+        const int8_t rssi = static_cast<int8_t>(advertisedDevice->getRSSI());
+#ifdef NIMBLE_V2
+        const uint8_t *mac = advertisedDevice->getAddress().getVal();
+#else
+        const uint8_t *mac = advertisedDevice->getAddress().getNative();
+#endif
+        // advData is only read by classify() for iBeacon detection; skipping it
+        // means iBeacons take the cold-then-promote path instead of jumping
+        // straight to HOT — a minor optimisation we can add later if it matters.
+        ClassifyResult result = tieredMemory->classify(mac, nullptr, 0, rssi);
+
+        if (result == ClassifyResult::DROP) {
+            tierDropCount.fetch_add(1, std::memory_order_relaxed);
+            if (onSeen) onSeen(false);
+            return;  // no slot-pool mutex, no heap allocation
+        }
+
+        if (result == ClassifyResult::COLD) {
+            bool shouldPromote = false;
+            if (xSemaphoreTake(coldMutex, MAX_WAIT) == pdTRUE) {
+                const uint32_t nowMs = millis();
+                ColdTier &cold = tieredMemory->coldTier();
+                cold.insert(mac, rssi, nowMs);  // create-or-update; increments seenCount
+                if (ColdRecord *rec = cold.lookup(mac)) {
+                    if (rec->seenCount >= DEFAULT_COLD_PROMOTION_COUNT &&
+                        rssi > DEFAULT_COLD_PROMOTION_RSSI) {
+                        shouldPromote = true;
+                        cold.remove(mac);  // leaving cold — avoid double-tracking
+                    }
+                }
+                xSemaphoreGive(coldMutex);
+            } else {
+                log_e("Couldn't take coldMutex in Seen");
+            }
+
+            if (!shouldPromote) {
+                tierColdCount.fetch_add(1, std::memory_order_relaxed);
+                if (onSeen) onSeen(false);
+                return;
+            }
+            tierPromoteCount.fetch_add(1, std::memory_order_relaxed);
+            // fall through to HOT path
+        }
+
+        tierHotCount.fetch_add(1, std::memory_order_relaxed);
+    }
+
     auto lease = GetFingerprint(advertisedDevice);
     if (lease && lease.fingerprint->seen(advertisedDevice) && onAdd)
         onAdd(lease.fingerprint);
@@ -223,6 +317,15 @@ enum class AddOrReplaceResult {
     Added,
     Replaced,
 };
+
+uint32_t getTierDropCount() { return tierDropCount.load(std::memory_order_relaxed); }
+uint32_t getTierColdCount() { return tierColdCount.load(std::memory_order_relaxed); }
+uint32_t getTierHotCount() { return tierHotCount.load(std::memory_order_relaxed); }
+uint32_t getTierPromoteCount() { return tierPromoteCount.load(std::memory_order_relaxed); }
+size_t getColdTierCapacity() { return tieredMemory ? tieredMemory->coldTier().capacity() : 0; }
+size_t getColdTierCount() { return tieredMemory ? tieredMemory->coldTier().count() : 0; }
+bool isColdTierUsingPsram() { return tieredMemory && tieredMemory->coldTier().isUsingPsram(); }
+bool isTieredMemoryEnabled() { return tieredMemoryReady(); }
 
 /**
  * @brief Add a device configuration or replace an existing one with the same id.

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -257,13 +257,21 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
     // for devices that actually matter. When the tier is disabled (alloc
     // failure or explicitly off) classify() returns HOT for everything and we
     // fall through to the original behaviour.
-    if (tieredMemoryReady()) {
+    if (tieredMemoryReady() && coldMutex != nullptr) {
         const int8_t rssi = static_cast<int8_t>(advertisedDevice->getRSSI());
+        // NimBLEAdvertisedDevice::getAddress() returns NimBLEAddress by VALUE;
+        // taking a pointer into the temporary via getVal()/getNative() in a
+        // single expression is UB — the temporary dies at the `;`. Copy the
+        // six bytes into a stack buffer that outlives every downstream call.
+        uint8_t mac[6];
+        {
+            const auto addr = advertisedDevice->getAddress();
 #ifdef NIMBLE_V2
-        const uint8_t *mac = advertisedDevice->getAddress().getVal();
+            memcpy(mac, addr.getVal(), 6);
 #else
-        const uint8_t *mac = advertisedDevice->getAddress().getNative();
+            memcpy(mac, addr.getNative(), 6);
 #endif
+        }
         // advData is only read by classify() for iBeacon detection; skipping it
         // means iBeacons take the cold-then-promote path instead of jumping
         // straight to HOT — a minor optimisation we can add later if it matters.

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -285,7 +285,8 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
         const uint8_t *advData = advertisedDevice->getPayload();
         const size_t advLen = advertisedDevice->getPayloadLength();
 #endif
-        ClassifyResult result = tieredMemory->classify(mac, advData, advLen, rssi);
+        uint8_t idType = ID_TYPE_MISC;
+        ClassifyResult result = tieredMemory->classify(mac, advData, advLen, rssi, &idType);
 
         if (result == ClassifyResult::DROP) {
             tierDropCount.fetch_add(1, std::memory_order_relaxed);
@@ -298,7 +299,10 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
             if (xSemaphoreTake(coldMutex, MAX_WAIT) == pdTRUE) {
                 const uint32_t nowMs = millis();
                 ColdTier &cold = tieredMemory->coldTier();
-                cold.insert(mac, rssi, nowMs);  // create-or-update; increments seenCount
+                // Pass idType so eviction bonuses (iBeacon +50, known-MAC +100)
+                // actually get applied — without this, idType stays ID_TYPE_MISC
+                // and EvictionScorer's bonuses are dead code.
+                cold.insert(mac, rssi, nowMs, idType);  // create-or-update; increments seenCount
                 if (ColdRecord *rec = cold.lookup(mac)) {
                     if (rec->seenCount >= DEFAULT_COLD_PROMOTION_COUNT &&
                         rssi > DEFAULT_COLD_PROMOTION_RSSI) {

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -272,10 +272,20 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
             memcpy(mac, addr.getNative(), 6);
 #endif
         }
-        // advData is only read by classify() for iBeacon detection; skipping it
-        // means iBeacons take the cold-then-promote path instead of jumping
-        // straight to HOT — a minor optimisation we can add later if it matters.
-        ClassifyResult result = tieredMemory->classify(mac, nullptr, 0, rssi);
+        // Pass the raw advertisement payload so classify()'s isIBeacon() check
+        // can fire — iBeacons (02 15 prefix) go straight to HOT instead of
+        // taking the cold-then-promote path. Important for presence tracking:
+        // most deployed beacons are iBeacons and we don't want 5 sightings of
+        // latency before they show up.
+#ifdef NIMBLE_V2
+        const auto payload = advertisedDevice->getPayload();
+        const uint8_t *advData = payload.data();
+        const size_t advLen = payload.size();
+#else
+        const uint8_t *advData = advertisedDevice->getPayload();
+        const size_t advLen = advertisedDevice->getPayloadLength();
+#endif
+        ClassifyResult result = tieredMemory->classify(mac, advData, advLen, rssi);
 
         if (result == ClassifyResult::DROP) {
             tierDropCount.fetch_add(1, std::memory_order_relaxed);

--- a/src/BleFingerprintCollection.h
+++ b/src/BleFingerprintCollection.h
@@ -55,6 +55,16 @@ size_t Size(bool cleanup = true);
 bool FindDeviceConfig(const String &id, DeviceConfig &config);
 bool FindDeviceConfigByAlias(const String &alias, DeviceConfig &config);
 
+// Tiered memory (ColdTier pre-filter) observability
+uint32_t getTierDropCount();
+uint32_t getTierColdCount();
+uint32_t getTierHotCount();
+uint32_t getTierPromoteCount();
+size_t getColdTierCapacity();
+size_t getColdTierCount();
+bool isColdTierUsingPsram();
+bool isTieredMemoryEnabled();
+
 extern TCallbackBool onSeen;
 extern TCallbackFingerprint onAdd;
 extern TCallbackFingerprint onDel;

--- a/src/BleMemoryTier.h
+++ b/src/BleMemoryTier.h
@@ -203,9 +203,13 @@ public:
      * @param advData Advertisement data (may be null)
      * @param advLen Length of advertisement data
      * @param rssi Signal strength
+     * @param outIdType Optional out-param receiving the detected idType
+     *                  (ID_TYPE_IBEACON / ID_TYPE_KNOWN_MAC / ID_TYPE_MISC).
+     *                  Written whenever the result is not DROP.
      * @return ClassifyResult (DROP, COLD, or HOT)
      */
-    ClassifyResult classify(const uint8_t* mac, const uint8_t* advData, size_t advLen, int8_t rssi) {
+    ClassifyResult classify(const uint8_t* mac, const uint8_t* advData, size_t advLen,
+                            int8_t rssi, uint8_t* outIdType = nullptr) {
         // Drop weak signals immediately - most common case, check first
         if (rssi < MIN_RSSI) {
             return ClassifyResult::DROP;
@@ -213,20 +217,21 @@ public:
 
         // Known MACs always go HOT
         if (isKnownMac(mac)) {
+            if (outIdType) *outIdType = ID_TYPE_KNOWN_MAC;
             return ClassifyResult::HOT;
         }
 
         // Check for iBeacon signature
         if (isIBeacon(advData, advLen)) {
+            if (outIdType) *outIdType = ID_TYPE_IBEACON;
             return ClassifyResult::HOT;
         }
 
-        // Moderate RSSI goes to COLD
-        if (rssi < MIN_RSSI_COLD) {
-            return ClassifyResult::COLD;
-        }
-
-        // Default: COLD tier for unknown devices with decent signal
+        // Unknown device above the drop floor: park in COLD. Promotion to HOT
+        // is driven by repeated sightings (seenCount) in ColdTier, not by
+        // instantaneous RSSI — a close-range random-MAC advertiser that only
+        // beacons once should not consume a hot slot.
+        if (outIdType) *outIdType = ID_TYPE_MISC;
         return ClassifyResult::COLD;
     }
 
@@ -264,12 +269,7 @@ inline ClassifyResult quickClassify(const uint8_t* mac, const uint8_t* advData, 
         return ClassifyResult::DROP;
     }
 
-    // Moderate RSSI goes to COLD
-    if (rssi < QuickClassifier::MIN_RSSI_COLD) {
-        return ClassifyResult::COLD;
-    }
-
-    // Default: COLD tier
+    // Unknown devices go to COLD regardless of RSSI (promotion is sighting-driven)
     return ClassifyResult::COLD;
 }
 
@@ -324,9 +324,13 @@ public:
      * @param mac 6-byte MAC address
      * @param rssi Signal strength
      * @param nowMs Current timestamp
+     * @param idType Device classification hint (ID_TYPE_IBEACON / ID_TYPE_KNOWN_MAC /
+     *               ID_TYPE_MISC). Stored on the record so EvictionScorer / eviction
+     *               bonuses actually fire; without this the field is always 0 and
+     *               the scoring is dead code.
      * @return true if inserted/updated
      */
-    bool insert(const uint8_t* mac, int8_t rssi, uint32_t nowMs) {
+    bool insert(const uint8_t* mac, int8_t rssi, uint32_t nowMs, uint8_t idType = ID_TYPE_MISC) {
         if (!isEnabled()) return false;
 
         // Single probe pass: find existing OR first available slot
@@ -369,6 +373,11 @@ public:
             if (existing->seenCount < 255) {
                 existing->seenCount++;
             }
+            // Upgrade classification if caller has a stronger signal this time
+            // (e.g. first sighting missed the iBeacon payload). Never downgrade.
+            if (existing->idType == ID_TYPE_MISC && idType != ID_TYPE_MISC) {
+                existing->idType = idType;
+            }
             MEM_LOG("Updated MAC %02X:..:%02X rssi=%d seen=%d",
                     mac[0], mac[5], rssi, existing->seenCount);
             return true;
@@ -404,6 +413,7 @@ public:
         record->lastSeenMs = nowMs;
         record->firstSeenMs = nowMs;
         record->seenCount = 1;
+        record->idType = idType;  // Feeds EvictionScorer bonuses for iBeacon/known-MAC
         record->setValid();
 
         count_++;
@@ -896,13 +906,15 @@ public:
      * @return Classification result
      */
     ClassifyResult classify(const uint8_t* mac, const uint8_t* advData,
-                            size_t advLen, int8_t rssi) {
+                            size_t advLen, int8_t rssi,
+                            uint8_t* outIdType = nullptr) {
         if (!config_.enabled) {
             // Backward compatibility: everything goes to HOT
+            if (outIdType) *outIdType = ID_TYPE_MISC;
             return ClassifyResult::HOT;
         }
 
-        return classifier_.classify(mac, advData, advLen, rssi);
+        return classifier_.classify(mac, advData, advLen, rssi, outIdType);
     }
 
     /**

--- a/src/BleMemoryTier.h
+++ b/src/BleMemoryTier.h
@@ -1,0 +1,942 @@
+/**
+ * @file BleMemoryTier.h
+ * @brief Tiered memory management for ESPresense BLE tracking
+ *
+ * This module implements a three-tier memory architecture to prevent OOM:
+ * - HOT tier: Full BleFingerprint objects (~400 bytes) for valuable devices
+ * - COLD tier: Lightweight ColdRecord structs (24 bytes) for less valuable devices
+ * - DROP tier: Rejected early, no memory allocated
+ *
+ * Key design principles:
+ * - Quick classification happens BEFORE heap allocation
+ * - Stack-only operations in the hot path
+ * - Single allocation at startup (no runtime malloc on MMU-less ESP32)
+ * - Value-based eviction using piecewise linear scoring (no exp())
+ * - Memory watchdog with safe restart via deep sleep
+ * - PSRAM support for WROVER devices with automatic fallback
+ */
+
+#pragma once
+#ifndef BLE_MEMORY_TIER_H
+#define BLE_MEMORY_TIER_H
+
+#include <cstdint>
+#include <cstring>
+#include <cmath>
+#include <cstdio>
+#include <new>
+
+// Logging support - define LOG_MEMORY_TIER to enable debug output
+#ifdef LOG_MEMORY_TIER
+#include <Arduino.h>
+#define MEM_LOG(fmt, ...) Serial.printf("[MemTier] " fmt "\n", ##__VA_ARGS__)
+#else
+#define MEM_LOG(fmt, ...) ((void)0)
+#endif
+
+#ifdef ESP32
+#include <esp_heap_caps.h>
+#include <esp_sleep.h>
+#include <esp_system.h>
+#else
+// Native testing - these are mocked in test file
+#ifndef UNIT_TEST
+// Only declare if not already defined in test file
+extern "C" {
+    size_t heap_caps_get_free_size(uint32_t caps);
+    size_t heap_caps_get_largest_free_block(uint32_t caps);
+}
+#endif
+#define MALLOC_CAP_INTERNAL 0
+#define MALLOC_CAP_SPIRAM 1
+#define MALLOC_CAP_8BIT 2
+#endif
+
+// ============================================================================
+// ID Type Constants (matching BleFingerprint.h values)
+// ============================================================================
+
+#ifndef ID_TYPE_IBEACON
+#define ID_TYPE_IBEACON 180
+#endif
+
+#ifndef ID_TYPE_KNOWN_MAC
+#define ID_TYPE_KNOWN_MAC 210
+#endif
+
+#ifndef ID_TYPE_MISC
+#define ID_TYPE_MISC 0
+#endif
+
+// ============================================================================
+// Classification Result
+// ============================================================================
+
+enum class ClassifyResult : uint8_t {
+    DROP = 0,   // Reject immediately, no memory allocated
+    COLD = 1,   // Store in lightweight cold tier
+    HOT = 2     // Promote to full BleFingerprint
+};
+
+// ============================================================================
+// ColdRecord - 24-byte lightweight device record
+// ============================================================================
+
+/**
+ * Compact device record for the cold tier.
+ * MUST be exactly 24 bytes for predictable memory usage.
+ * 128 records * 24 bytes = 3072 bytes (3KB)
+ *
+ * Design: Single allocation at startup, no runtime malloc.
+ * On MMU-less ESP32, memory turnover causes fragmentation.
+ */
+struct __attribute__((packed)) ColdRecord {
+    uint8_t mac[6];         // BLE MAC address (6 bytes)
+    int8_t rssi;            // Last RSSI reading (1 byte)
+    int8_t rssiMax;         // Maximum RSSI seen (1 byte)
+    uint8_t addrType;       // BLE address type (1 byte)
+    uint8_t idType;         // Classification hint (1 byte)
+    uint8_t flags;          // State bitfield (1 byte)
+    uint8_t seenCount;      // Times seen, capped at 255 (1 byte)
+    uint32_t lastSeenMs;    // Last seen timestamp (4 bytes)
+    uint32_t firstSeenMs;   // First seen timestamp (4 bytes)
+    int8_t rssiAvg;         // Running average RSSI (1 byte) - NOT sum to avoid overflow
+    uint8_t rssiSamples;    // Sample count for average (1 byte)
+    uint8_t reserved[2];    // Future use, alignment (2 bytes)
+    // Total: 6+1+1+1+1+1+1+4+4+1+1+2 = 24 bytes
+
+    // Flag bits - CRITICAL: tombstone support for hash table correctness
+    static constexpr uint8_t FLAG_EMPTY = 0x00;      // Never used slot
+    static constexpr uint8_t FLAG_VALID = 0x01;      // Active record
+    static constexpr uint8_t FLAG_TOMBSTONE = 0x02;  // Deleted but keep probing
+    static constexpr uint8_t FLAG_PROMOTED = 0x04;   // Promoted to HOT tier
+
+    bool isEmpty() const { return flags == FLAG_EMPTY; }
+    bool isValid() const { return flags & FLAG_VALID; }
+    bool isTombstone() const { return flags == FLAG_TOMBSTONE; }
+    bool canStopProbing() const { return isEmpty(); }  // Only stop on truly empty
+    bool canInsertHere() const { return isEmpty() || isTombstone(); }
+
+    void setValid() { flags = FLAG_VALID; }
+    void markTombstone() { flags = FLAG_TOMBSTONE; }  // CRITICAL: Don't clear(), use tombstone
+    bool isPromoted() const { return flags & FLAG_PROMOTED; }
+    void setPromoted() { flags |= FLAG_PROMOTED; }  // Add flag without clearing valid
+
+    void clear() {
+        memset(this, 0, sizeof(ColdRecord));
+        // flags is now FLAG_EMPTY (0x00) - truly empty slot
+    }
+
+    // Update running average RSSI without overflow
+    void updateRssiAverage(int8_t newRssi) {
+        if (rssiSamples < 255) {
+            // Exponential moving average: new_avg = old_avg * 0.875 + new * 0.125
+            // Using integer math: (old * 7 + new) / 8
+            int16_t newAvg = ((int16_t)rssiAvg * 7 + (int16_t)newRssi) / 8;
+            rssiAvg = (int8_t)newAvg;
+            rssiSamples++;
+        }
+    }
+};
+
+static_assert(sizeof(ColdRecord) == 24, "ColdRecord must be exactly 24 bytes");
+
+// ============================================================================
+// FNV-1a Hash Function
+// ============================================================================
+
+/**
+ * FNV-1a hash for MAC address lookup.
+ * Fast, deterministic, good distribution for small keys.
+ */
+inline uint32_t fnv1a_hash(const uint8_t* data, size_t len) {
+    uint32_t hash = 2166136261u;  // FNV offset basis
+    for (size_t i = 0; i < len; i++) {
+        hash ^= data[i];
+        hash *= 16777619u;  // FNV prime
+    }
+    return hash;
+}
+
+// ============================================================================
+// Quick Classifier - Stack-only classification
+// ============================================================================
+
+/**
+ * Quick classifier that determines device tier BEFORE heap allocation.
+ * All operations are stack-based to avoid contributing to memory pressure.
+ *
+ * Memory footprint: 192 bytes for known MAC list + 8 bytes overhead = ~200 bytes
+ * This is allocated ONCE at startup as part of TieredMemoryManager.
+ */
+class QuickClassifier {
+public:
+    static constexpr int8_t MIN_RSSI = -90;       // Drop below this
+    static constexpr int8_t MIN_RSSI_COLD = -85;  // Cold tier below this
+
+    QuickClassifier() : knownMacCount_(0) {
+        memset(knownMacs_, 0, sizeof(knownMacs_));
+    }
+
+    /**
+     * Add a MAC address to the known list (for HOT tier promotion).
+     * @param mac 6-byte MAC address
+     * @return true if added, false if list full
+     */
+    bool addKnownMac(const uint8_t* mac) {
+        if (knownMacCount_ >= MAX_KNOWN_MACS) {
+            MEM_LOG("Known MAC list full (%zu)", MAX_KNOWN_MACS);
+            return false;
+        }
+        memcpy(knownMacs_[knownMacCount_], mac, 6);
+        knownMacCount_++;
+        MEM_LOG("Added known MAC: %02X:%02X:%02X:%02X:%02X:%02X",
+                mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+        return true;
+    }
+
+    /**
+     * Classify a device based on MAC, advertisement data, and RSSI.
+     * IMPORTANT: This runs in BLE callback context - keep it fast, no heap alloc.
+     *
+     * @param mac 6-byte MAC address
+     * @param advData Advertisement data (may be null)
+     * @param advLen Length of advertisement data
+     * @param rssi Signal strength
+     * @return ClassifyResult (DROP, COLD, or HOT)
+     */
+    ClassifyResult classify(const uint8_t* mac, const uint8_t* advData, size_t advLen, int8_t rssi) {
+        // Drop weak signals immediately - most common case, check first
+        if (rssi < MIN_RSSI) {
+            return ClassifyResult::DROP;
+        }
+
+        // Known MACs always go HOT
+        if (isKnownMac(mac)) {
+            return ClassifyResult::HOT;
+        }
+
+        // Check for iBeacon signature
+        if (isIBeacon(advData, advLen)) {
+            return ClassifyResult::HOT;
+        }
+
+        // Moderate RSSI goes to COLD
+        if (rssi < MIN_RSSI_COLD) {
+            return ClassifyResult::COLD;
+        }
+
+        // Default: COLD tier for unknown devices with decent signal
+        return ClassifyResult::COLD;
+    }
+
+private:
+    static constexpr size_t MAX_KNOWN_MACS = 32;
+    uint8_t knownMacs_[MAX_KNOWN_MACS][6];
+    size_t knownMacCount_;
+
+    bool isKnownMac(const uint8_t* mac) const {
+        for (size_t i = 0; i < knownMacCount_; i++) {
+            if (memcmp(knownMacs_[i], mac, 6) == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool isIBeacon(const uint8_t* advData, size_t advLen) const {
+        // iBeacon format: 0x02 0x15 followed by 21 bytes (UUID + Major + Minor + TX)
+        if (advData == nullptr || advLen < 23) return false;
+        return (advData[0] == 0x02 && advData[1] == 0x15);
+    }
+};
+
+/**
+ * Free function for simple classification without known MAC tracking.
+ */
+inline ClassifyResult quickClassify(const uint8_t* mac, const uint8_t* advData, size_t advLen, int8_t rssi) {
+    (void)mac;  // Unused in simple version
+    (void)advData;
+    (void)advLen;
+
+    // Drop weak signals immediately
+    if (rssi < QuickClassifier::MIN_RSSI) {
+        return ClassifyResult::DROP;
+    }
+
+    // Moderate RSSI goes to COLD
+    if (rssi < QuickClassifier::MIN_RSSI_COLD) {
+        return ClassifyResult::COLD;
+    }
+
+    // Default: COLD tier
+    return ClassifyResult::COLD;
+}
+
+// ============================================================================
+// Cold Tier - Hash table of ColdRecords with PSRAM support
+// ============================================================================
+
+/**
+ * Cold tier storage using open addressing hash table with tombstone deletion.
+ *
+ * CRITICAL DESIGN DECISIONS:
+ * 1. Single allocation at startup - no runtime malloc (MMU-less device safety)
+ * 2. PSRAM preferred if available, fallback to internal SRAM
+ * 3. Tombstone deletion to maintain hash chain integrity
+ * 4. Fixed capacity for predictable memory usage
+ */
+class ColdTier {
+public:
+    static constexpr size_t DEFAULT_CAPACITY = 128;
+
+    // Non-copyable, non-movable (owns heap memory)
+    ColdTier(const ColdTier&) = delete;
+    ColdTier& operator=(const ColdTier&) = delete;
+    ColdTier(ColdTier&&) = delete;
+    ColdTier& operator=(ColdTier&&) = delete;
+
+    explicit ColdTier(size_t capacity = DEFAULT_CAPACITY)
+        : capacity_(capacity > 0 ? capacity : 1), count_(0), tombstoneCount_(0),
+          records_(nullptr), usingPsram_(false) {
+
+        allocateStorage();
+    }
+
+    ~ColdTier() {
+        freeStorage();
+    }
+
+    /**
+     * Check if cold tier is operational (allocation succeeded).
+     */
+    bool isEnabled() const {
+        bool enabled = records_ != nullptr && capacity_ > 0;
+        // DEBUG: Log the actual values for debugging crashes on memory-constrained devices
+        MEM_LOG("isEnabled: records_=%p capacity_=%zu -> %d",
+                (void*)records_, capacity_, enabled);
+        return enabled;
+    }
+    bool isUsingPsram() const { return usingPsram_; }
+
+    /**
+     * Insert or update a device in the cold tier.
+     * @param mac 6-byte MAC address
+     * @param rssi Signal strength
+     * @param nowMs Current timestamp
+     * @return true if inserted/updated
+     */
+    bool insert(const uint8_t* mac, int8_t rssi, uint32_t nowMs) {
+        if (!isEnabled()) return false;
+
+        // Single probe pass: find existing OR first available slot
+        size_t insertSlot = capacity_;  // Invalid sentinel
+        ColdRecord* existing = nullptr;
+
+        uint32_t hash = fnv1a_hash(mac, 6);
+        size_t startSlot = hash % capacity_;
+
+        for (size_t i = 0; i < capacity_; i++) {
+            size_t slot = (startSlot + i) % capacity_;
+            ColdRecord* record = &records_[slot];
+
+            if (record->isValid()) {
+                if (memcmp(record->mac, mac, 6) == 0) {
+                    existing = record;
+                    break;  // Found existing
+                }
+                // Continue probing
+            } else if (record->canInsertHere()) {
+                // First available slot (empty or tombstone)
+                if (insertSlot == capacity_) {
+                    insertSlot = slot;
+                }
+                if (record->canStopProbing()) {
+                    break;  // Truly empty = end of chain, item not found
+                }
+                // Tombstone: remember slot but keep searching for existing
+            }
+        }
+
+        if (existing) {
+            // Update existing record
+            existing->rssi = rssi;
+            existing->lastSeenMs = nowMs;  // CRITICAL: Update timestamp for eviction
+            existing->updateRssiAverage(rssi);
+            if (rssi > existing->rssiMax) {
+                existing->rssiMax = rssi;
+            }
+            if (existing->seenCount < 255) {
+                existing->seenCount++;
+            }
+            MEM_LOG("Updated MAC %02X:..:%02X rssi=%d seen=%d",
+                    mac[0], mac[5], rssi, existing->seenCount);
+            return true;
+        }
+
+        // Check if we should evict (table > 75% full including tombstones)
+        size_t totalUsed = count_ + tombstoneCount_;
+        if (totalUsed >= (capacity_ * 3) / 4) {
+            size_t evictedSlot = evictLowestValue(nowMs);
+            // Use evicted slot if we don't have one yet
+            if (insertSlot == capacity_ && evictedSlot < capacity_) {
+                insertSlot = evictedSlot;
+            }
+        }
+
+        // Need to insert new record
+        if (insertSlot == capacity_) {
+            // Table completely full (shouldn't happen with proper load factor)
+            MEM_LOG("Hash table completely full!");
+            return false;
+        }
+
+        // Insert new record
+        ColdRecord* record = &records_[insertSlot];
+        bool wasTombstone = record->isTombstone();
+
+        record->clear();  // Reset to empty first
+        memcpy(record->mac, mac, 6);
+        record->rssi = rssi;
+        record->rssiMax = rssi;
+        record->rssiAvg = rssi;
+        record->rssiSamples = 1;
+        record->lastSeenMs = nowMs;
+        record->firstSeenMs = nowMs;
+        record->seenCount = 1;
+        record->setValid();
+
+        count_++;
+        if (wasTombstone) {
+            tombstoneCount_--;  // Reused a tombstone slot
+        }
+
+        MEM_LOG("Inserted MAC %02X:..:%02X at slot %zu (count=%zu, tomb=%zu)",
+                mac[0], mac[5], insertSlot, count_, tombstoneCount_);
+        return true;
+    }
+
+    /**
+     * Look up a device by MAC address.
+     * Uses tombstone-aware probing - only stops on truly empty slots.
+     *
+     * @param mac 6-byte MAC address
+     * @return Pointer to record, or nullptr if not found
+     */
+    ColdRecord* lookup(const uint8_t* mac) {
+        if (!isEnabled()) return nullptr;
+
+        uint32_t hash = fnv1a_hash(mac, 6);
+        size_t startSlot = hash % capacity_;
+
+        // Linear probing with tombstone awareness
+        for (size_t i = 0; i < capacity_; i++) {
+            size_t slot = (startSlot + i) % capacity_;
+            ColdRecord* record = &records_[slot];
+
+            if (record->canStopProbing()) {
+                return nullptr;  // Truly empty = end of chain
+            }
+
+            if (record->isValid() && memcmp(record->mac, mac, 6) == 0) {
+                return record;
+            }
+            // Continue probing on tombstones and non-matching valid records
+        }
+
+        return nullptr;
+    }
+
+    /**
+     * Update an existing record with new RSSI and timestamp.
+     * @param mac 6-byte MAC address
+     * @param rssi New signal strength
+     * @param nowMs Current timestamp (CRITICAL for eviction)
+     */
+    void update(const uint8_t* mac, int8_t rssi, uint32_t nowMs = 0) {
+        ColdRecord* record = lookup(mac);
+        if (record) {
+            record->rssi = rssi;
+            if (nowMs > 0) {
+                record->lastSeenMs = nowMs;  // CRITICAL: Update timestamp
+            }
+            record->updateRssiAverage(rssi);
+            if (rssi > record->rssiMax) {
+                record->rssiMax = rssi;
+            }
+            if (record->seenCount < 255) {
+                record->seenCount++;
+            }
+        }
+    }
+
+    size_t count() const { return count_; }
+    size_t capacity() const { return capacity_; }
+    size_t tombstoneCount() const { return tombstoneCount_; }
+
+    /**
+     * Get memory usage statistics for monitoring.
+     */
+    void getStats(size_t& used, size_t& tombstones, size_t& total, bool& psram) const {
+        used = count_;
+        tombstones = tombstoneCount_;
+        total = capacity_;
+        psram = usingPsram_;
+    }
+
+    /**
+     * Remove a record from the cold tier (mark as tombstone).
+     * Used when promoting a device to HOT tier.
+     * @return true if record was found and removed
+     */
+    bool remove(const uint8_t* mac) {
+        ColdRecord* record = lookup(mac);
+        if (record && record->isValid()) {
+            record->markTombstone();
+            // Defensive: prevent underflow
+            if (count_ > 0) {
+                count_--;
+            }
+            tombstoneCount_++;
+            return true;
+        }
+        return false;
+    }
+
+private:
+    size_t capacity_;
+    size_t count_;
+    size_t tombstoneCount_;
+    ColdRecord* records_;
+    bool usingPsram_;
+
+    void allocateStorage() {
+        size_t allocSize = sizeof(ColdRecord) * capacity_;
+        MEM_LOG("allocateStorage: capacity_=%zu allocSize=%zu", capacity_, allocSize);
+
+#ifdef ESP32
+        // Strategy: Prefer PSRAM for cold tier (it's cold data!)
+        // This frees precious internal SRAM for BLE/WiFi stack
+        records_ = (ColdRecord*)heap_caps_malloc(allocSize, MALLOC_CAP_SPIRAM);
+        if (records_) {
+            usingPsram_ = true;
+            MEM_LOG("Allocated %zu bytes in PSRAM for %zu records", allocSize, capacity_);
+        } else {
+            // Fallback to internal SRAM - use MALLOC_CAP_8BIT to ensure DRAM allocation
+            // NOTE: MALLOC_CAP_INTERNAL can return IRAM (0x400xxxxx) which causes
+            // LoadStoreError when accessed as data. MALLOC_CAP_8BIT ensures byte-addressable DRAM.
+            records_ = (ColdRecord*)heap_caps_malloc(allocSize, MALLOC_CAP_8BIT);
+            usingPsram_ = false;
+            if (records_) {
+                MEM_LOG("Allocated %zu bytes in internal SRAM (no PSRAM)", allocSize);
+            } else {
+                MEM_LOG("CRITICAL: Failed to allocate cold tier storage!");
+                capacity_ = 0;
+            }
+        }
+#else
+        // Native testing
+        records_ = new (std::nothrow) ColdRecord[capacity_];
+        usingPsram_ = false;
+#endif
+
+        // Initialize all slots to empty
+        if (records_) {
+            for (size_t i = 0; i < capacity_; i++) {
+                records_[i].clear();
+            }
+        }
+    }
+
+    void freeStorage() {
+#ifdef ESP32
+        if (records_) {
+            heap_caps_free(records_);
+        }
+#else
+        delete[] records_;
+#endif
+        records_ = nullptr;
+    }
+
+    /**
+     * Evict the lowest-value record using scoring.
+     * Uses tombstone marking to maintain hash chain integrity.
+     * @return Slot index of evicted record, or capacity_ if none evicted
+     */
+    size_t evictLowestValue(uint32_t nowMs) {
+        if (count_ == 0) return capacity_;
+
+        float minScore = INFINITY;
+        size_t victim = capacity_;
+
+        for (size_t i = 0; i < capacity_; i++) {
+            if (!records_[i].isValid()) continue;
+
+            // Calculate simple eviction score (higher = keep, lower = evict)
+            float score = calculateEvictionScore(records_[i], nowMs);
+
+            if (score < minScore) {
+                minScore = score;
+                victim = i;
+            }
+        }
+
+        if (victim < capacity_ && records_[victim].isValid()) {
+            MEM_LOG("Evicting MAC %02X:..:%02X (score=%.1f) at slot %zu",
+                    records_[victim].mac[0], records_[victim].mac[5], minScore, victim);
+
+            // CRITICAL: Use tombstone, don't clear()!
+            records_[victim].markTombstone();
+            count_--;
+            tombstoneCount_++;
+        }
+
+        // Tombstone reuse in insert() naturally manages table health.
+        // No compaction needed - insert() reuses tombstone slots.
+
+        return victim;
+    }
+
+    /**
+     * Simple eviction score using integer math (ESP32 friendly).
+     * Higher score = more valuable = less likely to evict.
+     */
+    float calculateEvictionScore(const ColdRecord& record, uint32_t nowMs) const {
+        float score = 1.0f;
+
+        // ID type bonus
+        if (record.idType == ID_TYPE_KNOWN_MAC) {
+            score += 100.0f;
+        } else if (record.idType == ID_TYPE_IBEACON) {
+            score += 50.0f;
+        }
+
+        // Age penalty (linear: -1 point per minute since last seen)
+        uint32_t ageMs = nowMs - record.lastSeenMs;
+        float ageMinutes = (float)ageMs / 60000.0f;
+        score -= ageMinutes;
+
+        // Seen count bonus (devices seen often are more valuable)
+        if (record.seenCount > 10) {
+            score += 5.0f;
+        } else if (record.seenCount > 5) {
+            score += 3.0f;
+        }
+
+        // RSSI bonus (stronger signal = closer = more valuable)
+        if (record.rssiMax > -60) {
+            score += 3.0f;
+        } else if (record.rssiMax > -70) {
+            score += 1.0f;
+        }
+
+        return score > 0 ? score : 0.0f;
+    }
+};
+
+// ============================================================================
+// Memory Watchdog with Deep Sleep Restart
+// ============================================================================
+
+/**
+ * Memory watchdog that monitors heap and triggers safe restart if needed.
+ *
+ * Deep sleep strategy for SRAM clearing:
+ * - ESP32 deep sleep clears most SRAM (only RTC slow mem preserved ~8KB)
+ * - On wake, BLE/WiFi stack reinitializes with fresh memory
+ * - Rate-limited to prevent boot loops
+ */
+class MemoryWatchdog {
+public:
+    static constexpr size_t CRITICAL_HEAP = 30000;       // 30KB threshold (conservative)
+    static constexpr size_t WARNING_HEAP = 50000;        // 50KB warning threshold
+    static constexpr float FRAGMENTATION_RATIO = 0.5f;   // Largest block < 50% of free = fragmented
+    static constexpr int MAX_RESTARTS_PER_HOUR = 3;
+
+    MemoryWatchdog() : restartCount_(0), lastCheckMs_(0), consecutiveLowCount_(0) {}
+
+    /**
+     * Check if system is under memory pressure.
+     * @return true if free heap below critical threshold
+     */
+    bool isMemoryPressure() const {
+        size_t freeHeap = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+        return freeHeap < CRITICAL_HEAP;
+    }
+
+    /**
+     * Check if system is in warning zone (not critical but concerning).
+     */
+    bool isMemoryWarning() const {
+        size_t freeHeap = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+        return freeHeap < WARNING_HEAP;
+    }
+
+    /**
+     * Check if heap is fragmented.
+     * @return true if largest free block is small relative to total free
+     */
+    bool isFragmented() const {
+        size_t freeHeap = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+        size_t largestBlock = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
+
+        if (freeHeap == 0) return true;
+        return (float)largestBlock / (float)freeHeap < FRAGMENTATION_RATIO;
+    }
+
+    /**
+     * Check if restart is allowed (rate limited).
+     * @return true if restart count below limit
+     */
+    bool canRestart() const {
+        return restartCount_ < MAX_RESTARTS_PER_HOUR;
+    }
+
+    /**
+     * Record a restart attempt.
+     */
+    void recordRestart() {
+        restartCount_++;
+    }
+
+    /**
+     * Reset restart counter (call after 1 hour).
+     */
+    void resetRestartCount() {
+        restartCount_ = 0;
+    }
+
+    size_t getFreeHeap() const {
+        return heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+    }
+
+    size_t getLargestBlock() const {
+        return heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
+    }
+
+    /**
+     * Periodic check - call this from main loop every few seconds.
+     * Returns true if restart was triggered.
+     */
+    bool check(uint32_t nowMs) {
+        // Rate limit checks to every 5 seconds
+        if (nowMs - lastCheckMs_ < 5000) {
+            return false;
+        }
+        lastCheckMs_ = nowMs;
+
+#ifdef LOG_MEMORY_TIER
+        size_t freeHeap = getFreeHeap();
+        size_t largestBlock = getLargestBlock();
+        MEM_LOG("Heap: %zu free, %zu largest, frag=%.1f%%",
+                freeHeap, largestBlock,
+                freeHeap > 0 ? (1.0f - (float)largestBlock / freeHeap) * 100 : 100.0f);
+#endif
+
+        if (isMemoryPressure()) {
+            consecutiveLowCount_++;
+            MEM_LOG("MEMORY PRESSURE! consecutive=%d", consecutiveLowCount_);
+
+            // Trigger restart after 3 consecutive low readings (15 seconds)
+            if (consecutiveLowCount_ >= 3 && canRestart()) {
+                MEM_LOG("Triggering safe restart via deep sleep...");
+                triggerSafeRestart();
+                return true;
+            }
+        } else {
+            consecutiveLowCount_ = 0;
+        }
+
+        return false;
+    }
+
+    /**
+     * Trigger a safe restart using deep sleep.
+     * Deep sleep clears most SRAM, giving a fresh start.
+     */
+    void triggerSafeRestart() {
+#ifdef ESP32
+        recordRestart();
+
+        MEM_LOG("=== INITIATING DEEP SLEEP RESTART ===");
+        MEM_LOG("Free heap before: %zu", getFreeHeap());
+
+        // Very short deep sleep (100ms) to clear SRAM but wake quickly
+        // Deep sleep clears all SRAM except RTC slow memory (~8KB)
+        esp_sleep_enable_timer_wakeup(100 * 1000);  // 100ms in microseconds
+        esp_deep_sleep_start();
+
+        // Will not reach here - device restarts
+#else
+        MEM_LOG("Deep sleep restart not available on native platform");
+#endif
+    }
+
+private:
+    int restartCount_;
+    uint32_t lastCheckMs_;
+    int consecutiveLowCount_;
+};
+
+// ============================================================================
+// Eviction Scorer
+// ============================================================================
+
+/**
+ * Value-based eviction scoring using piecewise linear functions.
+ * Higher score = more valuable = less likely to evict.
+ * Uses no exp() or heavy math - ESP32 friendly.
+ */
+class EvictionScorer {
+public:
+    /**
+     * Calculate eviction score for a device.
+     * @param idType Device classification (iBeacon, known MAC, etc.)
+     * @param isIncluded Is device in include filter
+     * @param isExcluded Is device in exclude filter
+     * @param ageMs Age since last seen (milliseconds)
+     * @param distance Estimated distance (meters)
+     * @param seenCount Number of times seen
+     * @return Score (higher = more valuable, INFINITY = non-evictable)
+     */
+    float calculate(uint8_t idType, bool isIncluded, bool isExcluded,
+                    uint32_t ageMs, float distance, uint8_t seenCount) const {
+        // Excluded devices have lowest score
+        if (isExcluded) {
+            return 0.0f;
+        }
+
+        // Included devices are never evicted
+        if (isIncluded) {
+            return INFINITY;
+        }
+
+        float score = 1.0f;
+
+        // ID type bonus (piecewise)
+        if (idType == ID_TYPE_KNOWN_MAC) {
+            score += 100.0f;
+        } else if (idType == ID_TYPE_IBEACON) {
+            score += 50.0f;
+        }
+
+        // Age penalty (linear decay: -1 point per minute)
+        float ageMinutes = (float)ageMs / 60000.0f;
+        score -= ageMinutes;
+
+        // Distance penalty (linear: -1 point per meter beyond 2m)
+        if (distance > 2.0f) {
+            score -= (distance - 2.0f);
+        }
+
+        // Seen count bonus (logarithmic approximation using piecewise)
+        if (seenCount > 10) {
+            score += 5.0f;
+        } else if (seenCount > 5) {
+            score += 3.0f;
+        } else if (seenCount > 1) {
+            score += 1.0f;
+        }
+
+        return score > 0 ? score : 0.0f;
+    }
+};
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/**
+ * Configuration for tiered memory management.
+ * Conservative defaults for stability.
+ */
+struct TieredMemoryConfig {
+    bool enabled = true;
+    size_t maxHot = 64;           // Max HOT tier devices
+    size_t maxCold = 128;         // Max COLD tier records (reduced from 256)
+    int8_t minRssi = -90;         // Drop below this RSSI
+    int8_t minRssiCold = -85;     // COLD tier below this RSSI
+    size_t criticalHeap = 30000;  // Increased from 20KB for more headroom
+    int maxRestartsPerHour = 3;   // Rate limit restarts
+};
+
+// ============================================================================
+// Tiered Memory Manager
+// ============================================================================
+
+/**
+ * Main manager that coordinates all tiers.
+ *
+ * Memory footprint (single allocation at startup):
+ * - QuickClassifier: ~200 bytes (stack, part of this object)
+ * - ColdTier: 3KB in PSRAM or SRAM
+ * - MemoryWatchdog: ~20 bytes (stack)
+ * Total: ~3.2KB (mostly in PSRAM if available)
+ */
+class TieredMemoryManager {
+public:
+    // Non-copyable (contains non-copyable ColdTier)
+    TieredMemoryManager(const TieredMemoryManager&) = delete;
+    TieredMemoryManager& operator=(const TieredMemoryManager&) = delete;
+
+    explicit TieredMemoryManager(const TieredMemoryConfig& config)
+        : config_(config), coldTier_(config.maxCold) {
+
+        MEM_LOG("TieredMemoryManager initialized: enabled=%d, maxCold=%zu, PSRAM=%d",
+                config_.enabled, config_.maxCold, coldTier_.isUsingPsram());
+    }
+
+    /**
+     * Classify a device and route to appropriate tier.
+     * @param mac 6-byte MAC address
+     * @param advData Advertisement data
+     * @param advLen Advertisement data length
+     * @param rssi Signal strength
+     * @return Classification result
+     */
+    ClassifyResult classify(const uint8_t* mac, const uint8_t* advData,
+                            size_t advLen, int8_t rssi) {
+        if (!config_.enabled) {
+            // Backward compatibility: everything goes to HOT
+            return ClassifyResult::HOT;
+        }
+
+        return classifier_.classify(mac, advData, advLen, rssi);
+    }
+
+    /**
+     * Periodic maintenance - call from main loop.
+     */
+    void tick(uint32_t nowMs) {
+        watchdog_.check(nowMs);
+    }
+
+    QuickClassifier& classifier() { return classifier_; }
+    ColdTier& coldTier() { return coldTier_; }
+    MemoryWatchdog& watchdog() { return watchdog_; }
+    const TieredMemoryConfig& config() const { return config_; }
+
+    /**
+     * Get status string for debugging.
+     */
+    void getStatus(char* buf, size_t bufLen) const {
+        size_t used, tombs, total;
+        bool psram;
+        coldTier_.getStats(used, tombs, total, psram);
+
+        snprintf(buf, bufLen,
+                 "Cold:%zu/%zu(t%zu) Heap:%zu PSRAM:%s",
+                 used, total, tombs,
+                 watchdog_.getFreeHeap(),
+                 psram ? "Y" : "N");
+    }
+
+private:
+    TieredMemoryConfig config_;
+    QuickClassifier classifier_;
+    ColdTier coldTier_;
+    MemoryWatchdog watchdog_;
+};
+
+#endif // BLE_MEMORY_TIER_H

--- a/src/BleMemoryTier.h
+++ b/src/BleMemoryTier.h
@@ -184,6 +184,7 @@ public:
      * @return true if added, false if list full
      */
     bool addKnownMac(const uint8_t* mac) {
+        if (isKnownMac(mac)) return true;  // idempotent: settings reload re-registers
         if (knownMacCount_ >= MAX_KNOWN_MACS) {
             MEM_LOG("Known MAC list full (%zu)", MAX_KNOWN_MACS);
             return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,26 @@ void heapCapsAllocFailedHook(size_t requestedSize, uint32_t caps, const char *fu
 }
 
 /**
+ * @brief Convert ESP reset reason enum to human-readable string.
+ * @return Pointer to static string describing the reset reason.
+ */
+const char* getResetReasonString() {
+    switch (esp_reset_reason()) {
+        case ESP_RST_POWERON:   return "power_on";
+        case ESP_RST_EXT:       return "external";
+        case ESP_RST_SW:        return "software";
+        case ESP_RST_PANIC:     return "panic";
+        case ESP_RST_INT_WDT:   return "int_watchdog";
+        case ESP_RST_TASK_WDT:  return "task_watchdog";
+        case ESP_RST_WDT:       return "watchdog";
+        case ESP_RST_DEEPSLEEP: return "deep_sleep";
+        case ESP_RST_BROWNOUT:  return "brownout";
+        case ESP_RST_SDIO:      return "sdio";
+        default:                return "unknown";
+    }
+}
+
+/**
  * @brief Publish device telemetry and perform online/discovery announcements.
  *
  * Attempts to send status and discovery payloads when the device is not marked online
@@ -60,6 +80,7 @@ bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned in
             && sendTeleSensorDiscovery("Free Mem", EC_DIAGNOSTIC, "{{ value_json.freeHeap }}", DEVICE_CLASS_NONE, "bytes")
             && (BleFingerprintCollection::countIds.isEmpty() ? sendDeleteDiscovery("sensor", "Count") : sendTeleSensorDiscovery("Count", EC_NONE, "{{ value_json.count }}"))
             && sendButtonDiscovery("Restart", EC_DIAGNOSTIC)
+            && sendTeleSensorDiscovery("Reset Reason", EC_DIAGNOSTIC, "{{ value_json.resetReason }}")
             && sendNumberDiscovery("Max Distance", EC_CONFIG)
             && sendNumberDiscovery("Absorption", EC_CONFIG)
 
@@ -115,6 +136,7 @@ bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned in
 #else
     doc["ver"] = ESP.getSketchMD5() + "-" + getBuildTimestamp();
 #endif
+    doc["resetReason"] = resetReason;
 
     if (!BleFingerprintCollection::countIds.isEmpty())
         doc["count"] = count;
@@ -462,6 +484,7 @@ void connectToMqtt() {
     mqttClient.setServer(mqttHost.c_str(), mqttPort);
     mqttClient.setWill(statusTopic.c_str(), 0, true, "offline");
     mqttClient.setCredentials(mqttUser.c_str(), mqttPass.c_str());
+    mqttClient.setKeepAlive(60);  // 60 seconds - more tolerant than default 15s
     mqttClient.connect();
 }
 
@@ -621,6 +644,10 @@ void setup() {
 #endif
     Log.printf("Pre-Setup Free Mem: %lu\r\n", static_cast<unsigned long>(ESP.getFreeHeap()));
     heap_caps_register_failed_alloc_callback(heapCapsAllocFailedHook);
+
+    // Capture reset reason immediately on boot
+    resetReason = getResetReasonString();
+    Log.printf("Reset reason: %s\r\n", resetReason);
 
 #if M5STICK
     AXP192::Setup();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,7 +185,7 @@ bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned in
     if (pub(teleTopic.c_str(), 0, false, doc)) return true;
 
     teleFails++;
-    log_e("Error after 10 tries sending telemetry (%d times since boot)", teleFails);
+    log_e("Error sending telemetry (%d times since boot)", teleFails);
     return false;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -158,10 +158,29 @@ bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned in
     auto freeHeap = ESP.getFreeHeap();
     doc["freeHeap"] = freeHeap;
     doc["maxHeap"] = maxHeap;
+#ifdef ESP32
+    auto psramSize = ESP.getPsramSize();
+    if (psramSize > 0) {
+        doc["psram"] = psramSize;
+    }
+#endif
     doc["fingerprints"] = fingerprintCount;
     doc["scanStack"] = uxTaskGetStackHighWaterMark(scanTaskHandle);
     doc["loopStack"] = uxTaskGetStackHighWaterMark(nullptr);
     doc["bleStack"] = bleStack;
+
+    // Tiered memory (ColdTier pre-filter) stats — DEBUG: prune once stable
+    if (BleFingerprintCollection::isTieredMemoryEnabled()) {
+        doc["tierDrop"] = BleFingerprintCollection::getTierDropCount();
+        doc["tierCold"] = BleFingerprintCollection::getTierColdCount();
+        doc["tierHot"] = BleFingerprintCollection::getTierHotCount();
+        doc["tierPromote"] = BleFingerprintCollection::getTierPromoteCount();
+        doc["tierCap"] = BleFingerprintCollection::getColdTierCapacity();
+        doc["tierCount"] = BleFingerprintCollection::getColdTierCount();
+        if (BleFingerprintCollection::isColdTierUsingPsram()) {
+            doc["tierPsram"] = true;
+        }
+    }
 
     if (pub(teleTopic.c_str(), 0, false, doc)) return true;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,26 @@ void heapCapsAllocFailedHook(size_t requestedSize, uint32_t caps, const char *fu
 }
 
 /**
+ * @brief Convert ESP reset reason enum to human-readable string.
+ * @return Pointer to static string describing the reset reason.
+ */
+const char* getResetReasonString() {
+    switch (esp_reset_reason()) {
+        case ESP_RST_POWERON:   return "power_on";
+        case ESP_RST_EXT:       return "external";
+        case ESP_RST_SW:        return "software";
+        case ESP_RST_PANIC:     return "panic";
+        case ESP_RST_INT_WDT:   return "int_watchdog";
+        case ESP_RST_TASK_WDT:  return "task_watchdog";
+        case ESP_RST_WDT:       return "watchdog";
+        case ESP_RST_DEEPSLEEP: return "deep_sleep";
+        case ESP_RST_BROWNOUT:  return "brownout";
+        case ESP_RST_SDIO:      return "sdio";
+        default:                return "unknown";
+    }
+}
+
+/**
  * @brief Publish device telemetry and perform online/discovery announcements.
  *
  * Attempts to send status and discovery payloads when the device is not marked online
@@ -60,6 +80,7 @@ bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned in
             && sendTeleSensorDiscovery("Free Mem", EC_DIAGNOSTIC, "{{ value_json.freeHeap }}", DEVICE_CLASS_NONE, "bytes")
             && (BleFingerprintCollection::countIds.isEmpty() ? sendDeleteDiscovery("sensor", "Count") : sendTeleSensorDiscovery("Count", EC_NONE, "{{ value_json.count }}"))
             && sendButtonDiscovery("Restart", EC_DIAGNOSTIC)
+            && sendTeleSensorDiscovery("Reset Reason", EC_DIAGNOSTIC, "{{ value_json.resetReason }}")
             && sendNumberDiscovery("Max Distance", EC_CONFIG)
             && sendNumberDiscovery("Absorption", EC_CONFIG)
 
@@ -115,6 +136,7 @@ bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned in
 #else
     doc["ver"] = ESP.getSketchMD5() + "-" + getBuildTimestamp();
 #endif
+    doc["resetReason"] = resetReason;
 
     if (!BleFingerprintCollection::countIds.isEmpty())
         doc["count"] = count;
@@ -462,6 +484,7 @@ void connectToMqtt() {
     mqttClient.setServer(mqttHost.c_str(), mqttPort);
     mqttClient.setWill(statusTopic.c_str(), 0, true, "offline");
     mqttClient.setCredentials(mqttUser.c_str(), mqttPass.c_str());
+    mqttClient.setKeepAlive(60);  // 60 seconds - more tolerant than default 15s
     mqttClient.connect();
 }
 
@@ -622,6 +645,10 @@ void setup() {
 #endif
     Log.printf("Pre-Setup Free Mem: %lu\r\n", static_cast<unsigned long>(ESP.getFreeHeap()));
     heap_caps_register_failed_alloc_callback(heapCapsAllocFailedHook);
+
+    // Capture reset reason immediately on boot
+    resetReason = getResetReasonString();
+    Log.printf("Reset reason: %s\r\n", resetReason);
 
 #if M5STICK
     AXP192::Setup();

--- a/src/main.h
+++ b/src/main.h
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <AsyncTCP.h>
+#include <esp_system.h>
 #include <HeadlessWiFiSettings.h>
 #include <ESPAsyncWebServer.h>
 #include <HTTPClient.h>
@@ -62,6 +63,7 @@ int reportFailed = 0;
 bool online = false;         // Have we successfully sent status=online
 bool sentDiscovery = false;  // Have we successfully sent discovery
 UBaseType_t bleStack = 0;
+const char* resetReason = "unknown";  // Captured on boot
 
 int ethernetType = 0;
 String mqttHost, mqttUser, mqttPass;

--- a/src/main.h
+++ b/src/main.h
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <AsyncTCP.h>
+#include <esp_system.h>
 #include <HeadlessWiFiSettings.h>
 #include <ESPAsyncWebServer.h>
 #include <HTTPClient.h>
@@ -63,6 +64,7 @@ int reportFailed = 0;
 bool online = false;         // Have we successfully sent status=online
 bool sentDiscovery = false;  // Have we successfully sent discovery
 UBaseType_t bleStack = 0;
+const char* resetReason = "unknown";  // Captured on boot
 
 int ethernetType = 0;
 String mqttHost, mqttUser, mqttPass;

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -7,13 +7,9 @@
 
 bool pub(const char *topic, uint8_t qos, bool retain, const char *payload, size_t length, bool dup, uint16_t message_id)
 {
-    for (int i = 0; i < 10; i++)
-    {
-        if (mqttClient.publish(topic, qos, retain, payload, length, dup, message_id))
-            return true;
-        delay(25);
-    }
-    return false;
+    // Non-blocking publish - let AsyncMqttClient handle its own queue
+    // Blocking delays here prevent MQTT keepalive responses
+    return mqttClient.publish(topic, qos, retain, payload, length, dup, message_id);
 }
 
 bool pub(const char *topic, uint8_t qos, bool retain, JsonVariantConst jsonDoc, bool dup, uint16_t message_id)

--- a/test/test_memory_tier/test_memory_tier.cpp
+++ b/test/test_memory_tier/test_memory_tier.cpp
@@ -738,6 +738,117 @@ void test_remove_nonexistent_mac(void) {
 }
 
 // ============================================================================
+// idType propagation tests (regression: PR #2313 review)
+// ============================================================================
+
+void test_classifier_outputs_idtype_ibeacon(void) {
+    // iBeacon payload should report ID_TYPE_IBEACON via the out-param so
+    // EvictionScorer's +50 bonus can actually fire.
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+    uint8_t ibeaconData[25] = {0x02, 0x15};  // iBeacon prefix + 23 bytes
+
+    QuickClassifier classifier;
+    uint8_t idType = 0xFF;
+    ClassifyResult result = classifier.classify(mac, ibeaconData, sizeof(ibeaconData), -70, &idType);
+
+    TEST_ASSERT_EQUAL(ClassifyResult::HOT, result);
+    TEST_ASSERT_EQUAL(ID_TYPE_IBEACON, idType);
+}
+
+void test_classifier_outputs_idtype_known_mac(void) {
+    uint8_t knownMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
+    QuickClassifier classifier;
+    classifier.addKnownMac(knownMac);
+
+    uint8_t idType = 0xFF;
+    ClassifyResult result = classifier.classify(knownMac, nullptr, 0, -80, &idType);
+
+    TEST_ASSERT_EQUAL(ClassifyResult::HOT, result);
+    TEST_ASSERT_EQUAL(ID_TYPE_KNOWN_MAC, idType);
+}
+
+void test_classifier_outputs_idtype_misc_for_unknown(void) {
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    QuickClassifier classifier;
+    uint8_t idType = 0xFF;
+    ClassifyResult result = classifier.classify(mac, nullptr, 0, -70, &idType);
+
+    TEST_ASSERT_EQUAL(ClassifyResult::COLD, result);
+    TEST_ASSERT_EQUAL(ID_TYPE_MISC, idType);
+}
+
+void test_classifier_does_not_touch_idtype_on_drop(void) {
+    // Below MIN_RSSI: we should DROP without writing the out-param.
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    QuickClassifier classifier;
+    uint8_t idType = 0x77;  // sentinel
+    ClassifyResult result = classifier.classify(mac, nullptr, 0, -95, &idType);
+
+    TEST_ASSERT_EQUAL(ClassifyResult::DROP, result);
+    TEST_ASSERT_EQUAL(0x77, idType);  // untouched
+}
+
+void test_cold_tier_insert_stores_idtype(void) {
+    // Bug fix: ColdRecord.idType was never populated, so EvictionScorer
+    // bonuses for iBeacon/known-MAC were dead code.
+    ColdTier tier;
+    uint8_t mac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+
+    TEST_ASSERT_TRUE(tier.insert(mac, -70, 1000, ID_TYPE_IBEACON));
+    ColdRecord* rec = tier.lookup(mac);
+    TEST_ASSERT_NOT_NULL(rec);
+    TEST_ASSERT_EQUAL(ID_TYPE_IBEACON, rec->idType);
+}
+
+void test_cold_tier_insert_defaults_idtype_to_misc(void) {
+    // Existing callers that didn't pass idType should get ID_TYPE_MISC.
+    ColdTier tier;
+    uint8_t mac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+
+    TEST_ASSERT_TRUE(tier.insert(mac, -70, 1000));
+    ColdRecord* rec = tier.lookup(mac);
+    TEST_ASSERT_NOT_NULL(rec);
+    TEST_ASSERT_EQUAL(ID_TYPE_MISC, rec->idType);
+}
+
+void test_cold_tier_insert_upgrades_idtype_on_update(void) {
+    // First sighting missed the payload → MISC. Next sighting sees iBeacon
+    // prefix → record should upgrade to ID_TYPE_IBEACON (never downgrade).
+    ColdTier tier;
+    uint8_t mac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+
+    tier.insert(mac, -70, 1000, ID_TYPE_MISC);
+    tier.insert(mac, -68, 2000, ID_TYPE_IBEACON);
+
+    ColdRecord* rec = tier.lookup(mac);
+    TEST_ASSERT_NOT_NULL(rec);
+    TEST_ASSERT_EQUAL(ID_TYPE_IBEACON, rec->idType);
+
+    // And the reverse (don't downgrade known → misc)
+    tier.insert(mac, -68, 3000, ID_TYPE_MISC);
+    rec = tier.lookup(mac);
+    TEST_ASSERT_EQUAL(ID_TYPE_IBEACON, rec->idType);
+}
+
+void test_classifier_strong_rssi_unknown_stays_cold(void) {
+    // Dead-conditional fix: unknown device with strong signal still goes COLD
+    // because promotion is sighting-count driven, not RSSI-driven. This pins
+    // the behavior so a future "optimization" doesn't accidentally flip
+    // strong-signal unknowns to HOT (which would defeat the cold-tier filter).
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    QuickClassifier classifier;
+    ClassifyResult weakModerate = classifier.classify(mac, nullptr, 0, -88);  // just above drop
+    ClassifyResult strong       = classifier.classify(mac, nullptr, 0, -40);  // very close
+
+    TEST_ASSERT_EQUAL(ClassifyResult::COLD, weakModerate);
+    TEST_ASSERT_EQUAL(ClassifyResult::COLD, strong);
+}
+
+// ============================================================================
 // Test Runner
 // ============================================================================
 
@@ -816,6 +927,16 @@ int main(int argc, char **argv) {
     // Safety Tests (guard against underflow/invalid state)
     RUN_TEST(test_double_remove_no_underflow);
     RUN_TEST(test_remove_nonexistent_mac);
+
+    // idType propagation (regression: PR #2313 review)
+    RUN_TEST(test_classifier_outputs_idtype_ibeacon);
+    RUN_TEST(test_classifier_outputs_idtype_known_mac);
+    RUN_TEST(test_classifier_outputs_idtype_misc_for_unknown);
+    RUN_TEST(test_classifier_does_not_touch_idtype_on_drop);
+    RUN_TEST(test_cold_tier_insert_stores_idtype);
+    RUN_TEST(test_cold_tier_insert_defaults_idtype_to_misc);
+    RUN_TEST(test_cold_tier_insert_upgrades_idtype_on_update);
+    RUN_TEST(test_classifier_strong_rssi_unknown_stays_cold);
 
     return UNITY_END();
 }

--- a/test/test_memory_tier/test_memory_tier.cpp
+++ b/test/test_memory_tier/test_memory_tier.cpp
@@ -1,0 +1,821 @@
+/**
+ * @file test_memory_tier.cpp
+ * @brief Unit tests for ESPresense tiered memory management
+ *
+ * Tests for the tiered memory system including ColdRecord, ColdTier,
+ * QuickClassifier, MemoryWatchdog, and EvictionScorer components.
+ *
+ * Run with: pio test -e native-memory
+ */
+
+#include <unity.h>
+#include <cstring>
+#include <cstdint>
+
+#ifdef UNIT_TEST
+// Mock ESP32 heap functions for native testing
+static size_t mock_free_heap = 100000;
+static size_t mock_largest_block = 80000;
+
+extern "C" size_t heap_caps_get_free_size(uint32_t caps) {
+    (void)caps;
+    return mock_free_heap;
+}
+
+extern "C" size_t heap_caps_get_largest_free_block(uint32_t caps) {
+    (void)caps;
+    return mock_largest_block;
+}
+
+void set_mock_heap(size_t free_heap, size_t largest_block) {
+    mock_free_heap = free_heap;
+    mock_largest_block = largest_block;
+}
+#endif
+
+#include "BleMemoryTier.h"
+
+// ============================================================================
+// ColdRecord Tests
+// ============================================================================
+
+void test_ColdRecord_size_is_24_bytes(void) {
+    // ColdRecord must be exactly 24 bytes for predictable memory usage
+    // 256 records * 24 bytes = 6144 bytes (6KB)
+    TEST_ASSERT_EQUAL(24, sizeof(ColdRecord));
+}
+
+void test_ColdRecord_fields_are_correct_size(void) {
+    ColdRecord record = {};
+
+    TEST_ASSERT_EQUAL(6, sizeof(record.mac));
+    TEST_ASSERT_EQUAL(1, sizeof(record.rssi));
+    TEST_ASSERT_EQUAL(1, sizeof(record.rssiMax));
+    TEST_ASSERT_EQUAL(1, sizeof(record.addrType));
+    TEST_ASSERT_EQUAL(1, sizeof(record.idType));
+    TEST_ASSERT_EQUAL(1, sizeof(record.flags));
+    TEST_ASSERT_EQUAL(1, sizeof(record.seenCount));
+    TEST_ASSERT_EQUAL(4, sizeof(record.lastSeenMs));
+    TEST_ASSERT_EQUAL(4, sizeof(record.firstSeenMs));
+    TEST_ASSERT_EQUAL(1, sizeof(record.rssiAvg));
+    TEST_ASSERT_EQUAL(1, sizeof(record.rssiSamples));
+    TEST_ASSERT_EQUAL(2, sizeof(record.reserved));
+}
+
+void test_ColdRecord_tombstone_flags(void) {
+    ColdRecord record = {};
+    record.clear();
+
+    // Fresh record should be empty (not valid, not tombstone)
+    TEST_ASSERT_TRUE(record.isEmpty());
+    TEST_ASSERT_FALSE(record.isValid());
+    TEST_ASSERT_FALSE(record.isTombstone());
+    TEST_ASSERT_TRUE(record.canStopProbing());
+    TEST_ASSERT_TRUE(record.canInsertHere());
+
+    // Set valid
+    record.setValid();
+    TEST_ASSERT_FALSE(record.isEmpty());
+    TEST_ASSERT_TRUE(record.isValid());
+    TEST_ASSERT_FALSE(record.isTombstone());
+    TEST_ASSERT_FALSE(record.canStopProbing());
+    TEST_ASSERT_FALSE(record.canInsertHere());
+
+    // Mark as tombstone (critical for hash table correctness)
+    record.markTombstone();
+    TEST_ASSERT_FALSE(record.isEmpty());
+    TEST_ASSERT_FALSE(record.isValid());
+    TEST_ASSERT_TRUE(record.isTombstone());
+    TEST_ASSERT_FALSE(record.canStopProbing());
+    TEST_ASSERT_TRUE(record.canInsertHere());
+}
+
+void test_ColdRecord_rssi_average_no_overflow(void) {
+    ColdRecord record = {};
+    record.clear();
+    record.rssiAvg = -40;
+    record.rssiSamples = 1;
+
+    // Update with readings that would overflow int8_t if summed
+    for (int i = 0; i < 100; i++) {
+        record.updateRssiAverage(-90);
+    }
+
+    // Average should converge toward -90, not overflow
+    TEST_ASSERT_TRUE(record.rssiAvg < -80);
+    TEST_ASSERT_TRUE(record.rssiAvg > -100);
+    TEST_ASSERT_EQUAL(101, record.rssiSamples);
+}
+
+void test_cold_record_can_be_marked_promoted(void) {
+    ColdRecord record;
+    record.clear();
+    record.setValid();
+
+    TEST_ASSERT_FALSE(record.isPromoted());
+
+    record.setPromoted();
+    TEST_ASSERT_TRUE(record.isPromoted());
+    TEST_ASSERT_TRUE(record.isValid());
+}
+
+// ============================================================================
+// Hash Function Tests
+// ============================================================================
+
+void test_fnv1a_hash_is_deterministic(void) {
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    uint32_t hash1 = fnv1a_hash(mac, 6);
+    uint32_t hash2 = fnv1a_hash(mac, 6);
+
+    TEST_ASSERT_EQUAL_UINT32(hash1, hash2);
+}
+
+void test_fnv1a_hash_different_for_different_macs(void) {
+    uint8_t mac1[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+    uint8_t mac2[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
+    uint32_t hash1 = fnv1a_hash(mac1, 6);
+    uint32_t hash2 = fnv1a_hash(mac2, 6);
+
+    TEST_ASSERT_NOT_EQUAL(hash1, hash2);
+}
+
+// ============================================================================
+// Classifier Tests
+// ============================================================================
+
+void test_classifier_drops_weak_rssi(void) {
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    ClassifyResult result = quickClassify(mac, nullptr, 0, -95);
+    TEST_ASSERT_EQUAL(ClassifyResult::DROP, result);
+}
+
+void test_classifier_cold_for_moderate_rssi(void) {
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    ClassifyResult result = quickClassify(mac, nullptr, 0, -87);
+    TEST_ASSERT_EQUAL(ClassifyResult::COLD, result);
+}
+
+void test_classifier_hot_for_known_mac(void) {
+    uint8_t knownMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
+    QuickClassifier classifier;
+    classifier.addKnownMac(knownMac);
+
+    ClassifyResult result = classifier.classify(knownMac, nullptr, 0, -80);
+    TEST_ASSERT_EQUAL(ClassifyResult::HOT, result);
+}
+
+void test_classifier_hot_for_ibeacon(void) {
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    uint8_t ibeaconData[] = {
+        0x02, 0x15,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x01,
+        0x00, 0x02,
+        0xC5
+    };
+
+    QuickClassifier classifier;
+    ClassifyResult result = classifier.classify(mac, ibeaconData, sizeof(ibeaconData), -70);
+    TEST_ASSERT_EQUAL(ClassifyResult::HOT, result);
+}
+
+void test_classifier_default_is_cold(void) {
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    QuickClassifier classifier;
+    ClassifyResult result = classifier.classify(mac, nullptr, 0, -70);
+    TEST_ASSERT_EQUAL(ClassifyResult::COLD, result);
+}
+
+void test_classifier_under_memory_pressure(void) {
+    TieredMemoryConfig config;
+    config.criticalHeap = 30000;
+    TieredMemoryManager manager(config);
+
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    // Normal memory - moderate RSSI goes to COLD
+    set_mock_heap(100000, 80000);
+    ClassifyResult result = manager.classify(mac, nullptr, 0, -80);
+    TEST_ASSERT_EQUAL(ClassifyResult::COLD, result);
+
+    // Critical memory - system may adapt behavior
+    set_mock_heap(20000, 15000);
+    result = manager.classify(mac, nullptr, 0, -80);
+    TEST_ASSERT_TRUE(result == ClassifyResult::DROP || result == ClassifyResult::COLD);
+}
+
+// ============================================================================
+// Cold Tier Tests
+// ============================================================================
+
+void test_cold_tier_insert_and_lookup(void) {
+    ColdTier tier;
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    bool inserted = tier.insert(mac, -70, 0);
+    TEST_ASSERT_TRUE(inserted);
+
+    ColdRecord* found = tier.lookup(mac);
+    TEST_ASSERT_NOT_NULL(found);
+    TEST_ASSERT_EQUAL(-70, found->rssi);
+}
+
+void test_cold_tier_lookup_returns_null_for_missing(void) {
+    ColdTier tier;
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    ColdRecord* found = tier.lookup(mac);
+    TEST_ASSERT_NULL(found);
+}
+
+void test_cold_tier_update_existing(void) {
+    ColdTier tier;
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    tier.insert(mac, -70, 0);
+    tier.update(mac, -65);
+
+    ColdRecord* found = tier.lookup(mac);
+    TEST_ASSERT_NOT_NULL(found);
+    TEST_ASSERT_EQUAL(-65, found->rssi);
+    TEST_ASSERT_EQUAL(-65, found->rssiMax);
+}
+
+void test_cold_tier_evicts_oldest_when_full(void) {
+    ColdTier tier(8);
+
+    for (int i = 0; i < 6; i++) {
+        uint8_t mac[6] = {0, 0, 0, 0, 0, (uint8_t)i};
+        tier.insert(mac, -70 + i, i * 1000);
+    }
+
+    uint8_t newMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    bool inserted = tier.insert(newMac, -60, 60000);
+    TEST_ASSERT_TRUE(inserted);
+
+    uint8_t oldestMac[6] = {0, 0, 0, 0, 0, 0};
+    ColdRecord* found = tier.lookup(oldestMac);
+    TEST_ASSERT_NULL(found);
+
+    found = tier.lookup(newMac);
+    TEST_ASSERT_NOT_NULL(found);
+}
+
+void test_cold_tier_remove_promoted_record(void) {
+    ColdTier tier;
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    tier.insert(mac, -70, 0);
+    ColdRecord* record = tier.lookup(mac);
+    TEST_ASSERT_NOT_NULL(record);
+
+    record->setPromoted();
+    bool removed = tier.remove(mac);
+    TEST_ASSERT_TRUE(removed);
+
+    record = tier.lookup(mac);
+    TEST_ASSERT_NULL(record);
+}
+
+void test_cold_tier_remove_nonexistent_returns_false(void) {
+    ColdTier tier;
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    bool removed = tier.remove(mac);
+    TEST_ASSERT_FALSE(removed);
+}
+
+void test_cold_tier_update_increments_seen_count(void) {
+    ColdTier tier;
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    tier.insert(mac, -70, 0);
+    ColdRecord* record = tier.lookup(mac);
+    TEST_ASSERT_EQUAL(1, record->seenCount);
+
+    for (int i = 0; i < 10; i++) {
+        tier.update(mac, -70, (i + 1) * 1000);
+    }
+
+    record = tier.lookup(mac);
+    TEST_ASSERT_EQUAL(11, record->seenCount);
+}
+
+void test_cold_tier_seen_count_caps_at_255(void) {
+    ColdTier tier;
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    tier.insert(mac, -70, 0);
+
+    for (int i = 0; i < 300; i++) {
+        tier.update(mac, -70, i * 100);
+    }
+
+    ColdRecord* record = tier.lookup(mac);
+    TEST_ASSERT_EQUAL(255, record->seenCount);
+}
+
+void test_rssi_max_tracks_strongest_signal(void) {
+    ColdTier tier;
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    tier.insert(mac, -80, 0);
+    ColdRecord* record = tier.lookup(mac);
+    TEST_ASSERT_EQUAL(-80, record->rssiMax);
+
+    tier.update(mac, -90, 1000);
+    record = tier.lookup(mac);
+    TEST_ASSERT_EQUAL(-80, record->rssiMax);
+
+    tier.update(mac, -60, 2000);
+    record = tier.lookup(mac);
+    TEST_ASSERT_EQUAL(-60, record->rssiMax);
+
+    tier.update(mac, -70, 3000);
+    record = tier.lookup(mac);
+    TEST_ASSERT_EQUAL(-60, record->rssiMax);
+}
+
+void test_promotion_threshold_behavior(void) {
+    ColdTier tier;
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    tier.insert(mac, -80, 0);
+
+    for (int i = 1; i <= 4; i++) {
+        tier.update(mac, -80, i * 1000);
+    }
+    ColdRecord* record = tier.lookup(mac);
+    TEST_ASSERT_NOT_NULL(record);
+    TEST_ASSERT_EQUAL(5, record->seenCount);
+
+    tier.update(mac, -70, 5000);
+    record = tier.lookup(mac);
+    TEST_ASSERT_EQUAL(6, record->seenCount);
+    TEST_ASSERT_EQUAL(-70, record->rssi);
+}
+
+// ============================================================================
+// Memory Watchdog Tests
+// ============================================================================
+
+void test_watchdog_detects_low_memory(void) {
+    MemoryWatchdog watchdog;
+
+    set_mock_heap(25000, 20000);
+
+    TEST_ASSERT_TRUE(watchdog.isMemoryPressure());
+}
+
+void test_watchdog_ok_with_sufficient_memory(void) {
+    MemoryWatchdog watchdog;
+
+    set_mock_heap(100000, 80000);
+
+    TEST_ASSERT_FALSE(watchdog.isMemoryPressure());
+}
+
+void test_watchdog_detects_fragmentation(void) {
+    MemoryWatchdog watchdog;
+
+    set_mock_heap(100000, 20000);
+
+    TEST_ASSERT_TRUE(watchdog.isFragmented());
+}
+
+void test_watchdog_restart_rate_limited(void) {
+    MemoryWatchdog watchdog;
+
+    TEST_ASSERT_TRUE(watchdog.canRestart());
+    watchdog.recordRestart();
+
+    TEST_ASSERT_TRUE(watchdog.canRestart());
+    watchdog.recordRestart();
+
+    TEST_ASSERT_TRUE(watchdog.canRestart());
+    watchdog.recordRestart();
+
+    TEST_ASSERT_FALSE(watchdog.canRestart());
+}
+
+void test_watchdog_restart_window_reset(void) {
+    MemoryWatchdog watchdog;
+
+    watchdog.recordRestart();
+    watchdog.recordRestart();
+    watchdog.recordRestart();
+    TEST_ASSERT_FALSE(watchdog.canRestart());
+
+    watchdog.resetRestartCount();
+    TEST_ASSERT_TRUE(watchdog.canRestart());
+}
+
+void test_memory_pressure_transitions(void) {
+    MemoryWatchdog watchdog;
+
+    set_mock_heap(100000, 80000);
+    TEST_ASSERT_FALSE(watchdog.isMemoryPressure());
+    TEST_ASSERT_FALSE(watchdog.isFragmented());
+
+    set_mock_heap(50000, 45000);
+    TEST_ASSERT_FALSE(watchdog.isMemoryPressure());
+
+    set_mock_heap(35000, 30000);
+    TEST_ASSERT_FALSE(watchdog.isMemoryPressure());
+
+    set_mock_heap(25000, 20000);
+    TEST_ASSERT_TRUE(watchdog.isMemoryPressure());
+
+    set_mock_heap(60000, 50000);
+    TEST_ASSERT_FALSE(watchdog.isMemoryPressure());
+}
+
+void test_fragmentation_patterns(void) {
+    MemoryWatchdog watchdog;
+
+    set_mock_heap(100000, 80000);
+    TEST_ASSERT_FALSE(watchdog.isFragmented());
+
+    set_mock_heap(100000, 51000);
+    TEST_ASSERT_FALSE(watchdog.isFragmented());
+
+    set_mock_heap(100000, 49000);
+    TEST_ASSERT_TRUE(watchdog.isFragmented());
+
+    set_mock_heap(100000, 20000);
+    TEST_ASSERT_TRUE(watchdog.isFragmented());
+
+    set_mock_heap(29000, 27000);
+    TEST_ASSERT_FALSE(watchdog.isFragmented());
+    TEST_ASSERT_TRUE(watchdog.isMemoryPressure());
+}
+
+void test_simultaneous_pressure_and_fragmentation(void) {
+    MemoryWatchdog watchdog;
+
+    set_mock_heap(28000, 8000);
+
+    TEST_ASSERT_TRUE(watchdog.isMemoryPressure());
+    TEST_ASSERT_TRUE(watchdog.isFragmented());
+
+    TEST_ASSERT_TRUE(watchdog.getFreeHeap() < 30000);
+    TEST_ASSERT_TRUE(watchdog.getLargestBlock() < watchdog.getFreeHeap() / 2);
+}
+
+// ============================================================================
+// Eviction Scorer Tests
+// ============================================================================
+
+void test_eviction_score_higher_for_included_device(void) {
+    EvictionScorer scorer;
+
+    float includedScore = scorer.calculate(ID_TYPE_KNOWN_MAC, true, false, 1000, 5.0f, 10);
+    float normalScore = scorer.calculate(ID_TYPE_MISC, false, false, 1000, 5.0f, 10);
+
+    TEST_ASSERT_TRUE(includedScore > normalScore);
+    TEST_ASSERT_TRUE(isinf(includedScore));
+}
+
+void test_eviction_score_higher_for_ibeacon(void) {
+    EvictionScorer scorer;
+
+    float ibeaconScore = scorer.calculate(ID_TYPE_IBEACON, false, false, 1000, 5.0f, 10);
+    float miscScore = scorer.calculate(ID_TYPE_MISC, false, false, 1000, 5.0f, 10);
+
+    TEST_ASSERT_TRUE(ibeaconScore > miscScore);
+}
+
+void test_eviction_score_decays_with_age(void) {
+    EvictionScorer scorer;
+
+    float recentScore = scorer.calculate(ID_TYPE_MISC, false, false, 1000, 5.0f, 10);
+    float oldScore = scorer.calculate(ID_TYPE_MISC, false, false, 300000, 5.0f, 10);
+
+    TEST_ASSERT_TRUE(recentScore > oldScore);
+}
+
+void test_eviction_score_higher_for_closer_device(void) {
+    EvictionScorer scorer;
+
+    float closeScore = scorer.calculate(ID_TYPE_MISC, false, false, 1000, 1.0f, 10);
+    float farScore = scorer.calculate(ID_TYPE_MISC, false, false, 1000, 10.0f, 10);
+
+    TEST_ASSERT_TRUE(closeScore > farScore);
+}
+
+void test_eviction_prefers_weak_old_devices(void) {
+    EvictionScorer scorer;
+
+    float keepScore = scorer.calculate(ID_TYPE_IBEACON, false, false, 1000, 1.0f, 10);
+    float evictScore = scorer.calculate(ID_TYPE_MISC, false, false, 600000, 20.0f, 2);
+
+    TEST_ASSERT_TRUE(keepScore > evictScore);
+    TEST_ASSERT_TRUE(keepScore > evictScore * 5);
+}
+
+// ============================================================================
+// Configuration and Integration Tests
+// ============================================================================
+
+void test_tiered_memory_config_defaults(void) {
+    TieredMemoryConfig config;
+
+    TEST_ASSERT_TRUE(config.enabled);
+    TEST_ASSERT_EQUAL(64, config.maxHot);
+    TEST_ASSERT_EQUAL(128, config.maxCold);
+    TEST_ASSERT_EQUAL(-90, config.minRssi);
+    TEST_ASSERT_EQUAL(-85, config.minRssiCold);
+    TEST_ASSERT_EQUAL(30000, config.criticalHeap);
+    TEST_ASSERT_EQUAL(3, config.maxRestartsPerHour);
+}
+
+void test_backward_compatibility_when_disabled(void) {
+    TieredMemoryConfig config;
+    config.enabled = false;
+
+    TieredMemoryManager manager(config);
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    ClassifyResult result = manager.classify(mac, nullptr, 0, -95);
+    TEST_ASSERT_EQUAL(ClassifyResult::HOT, result);
+}
+
+void test_cold_tier_enabled_vs_disabled(void) {
+    // Verify isEnabled() correctly reflects allocation state
+    ColdTier tier(32);
+    TEST_ASSERT_TRUE(tier.isEnabled());
+    TEST_ASSERT_EQUAL(32, tier.capacity());
+
+    // A tier with capacity > 0 should be enabled and functional
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+    bool inserted = tier.insert(mac, -70, 0);
+    TEST_ASSERT_TRUE(inserted);  // Only works if enabled
+}
+
+void test_manager_classify_respects_enabled_flag(void) {
+    // When config.enabled=false, classify() should return HOT for everything
+    TieredMemoryConfig disabledConfig;
+    disabledConfig.enabled = false;
+    TieredMemoryManager disabledManager(disabledConfig);
+
+    uint8_t mac[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+
+    // Even weak signal (-95) should return HOT when disabled
+    ClassifyResult result = disabledManager.classify(mac, nullptr, 0, -95);
+    TEST_ASSERT_EQUAL(ClassifyResult::HOT, result);
+
+    // When enabled, weak signal should DROP
+    TieredMemoryConfig enabledConfig;
+    enabledConfig.enabled = true;
+    TieredMemoryManager enabledManager(enabledConfig);
+
+    result = enabledManager.classify(mac, nullptr, 0, -95);
+    TEST_ASSERT_EQUAL(ClassifyResult::DROP, result);
+}
+
+void test_cold_tier_reports_psram_usage(void) {
+    // In native tests, PSRAM is never available - verify accessor reports this
+    ColdTier tier;
+    TEST_ASSERT_FALSE(tier.isUsingPsram());
+
+    // Verify the tier still works without PSRAM
+    TEST_ASSERT_TRUE(tier.isEnabled());
+    uint8_t mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    TEST_ASSERT_TRUE(tier.insert(mac, -70, 0));
+}
+
+void test_manager_cold_tier_accessor(void) {
+    // Verify we can access cold tier stats through manager
+    TieredMemoryConfig config;
+    config.maxCold = 64;
+    TieredMemoryManager manager(config);
+
+    // Verify cold tier was created with correct capacity
+    TEST_ASSERT_EQUAL(64, manager.coldTier().capacity());
+    TEST_ASSERT_TRUE(manager.coldTier().isEnabled());
+
+    // Insert some records and verify count
+    uint8_t mac1[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    uint8_t mac2[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    manager.coldTier().insert(mac1, -70, 0);
+    manager.coldTier().insert(mac2, -75, 0);
+    TEST_ASSERT_EQUAL(2, manager.coldTier().count());
+}
+
+// ============================================================================
+// Stress Tests
+// ============================================================================
+
+void test_cold_tier_fill_and_evict_cycle(void) {
+    ColdTier tier(32);
+
+    for (int i = 0; i < 24; i++) {
+        uint8_t mac[6] = {0xAA, 0xBB, (uint8_t)(i >> 8), (uint8_t)(i & 0xFF), 0x00, 0x00};
+        bool inserted = tier.insert(mac, -70, i * 100);
+        TEST_ASSERT_TRUE(inserted);
+    }
+    TEST_ASSERT_EQUAL(24, tier.count());
+
+    for (int i = 0; i < 10; i++) {
+        uint8_t mac[6] = {0xCC, 0xDD, (uint8_t)(i >> 8), (uint8_t)(i & 0xFF), 0x00, 0x00};
+        tier.insert(mac, -60, 10000 + i * 100);
+    }
+
+    TEST_ASSERT_TRUE(tier.count() <= 24);
+}
+
+void test_cold_tier_tombstone_reuse(void) {
+    ColdTier tier(16);
+
+    uint8_t mac1[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    uint8_t mac2[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
+    tier.insert(mac1, -70, 0);
+    tier.insert(mac2, -75, 0);
+    TEST_ASSERT_EQUAL(2, tier.count());
+
+    tier.remove(mac1);
+    TEST_ASSERT_EQUAL(1, tier.count());
+
+    ColdRecord* found = tier.lookup(mac2);
+    TEST_ASSERT_NOT_NULL(found);
+
+    uint8_t mac3[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x77};
+    tier.insert(mac3, -65, 0);
+    TEST_ASSERT_EQUAL(2, tier.count());
+
+    TEST_ASSERT_NULL(tier.lookup(mac1));
+    TEST_ASSERT_NOT_NULL(tier.lookup(mac2));
+    TEST_ASSERT_NOT_NULL(tier.lookup(mac3));
+}
+
+void test_cold_tier_high_collision_scenario(void) {
+    ColdTier tier(32);
+
+    for (int i = 0; i < 20; i++) {
+        uint8_t mac[6] = {0x00, 0x00, 0x00, 0x00, (uint8_t)(i >> 8), (uint8_t)(i & 0xFF)};
+        bool inserted = tier.insert(mac, -70 + (i % 20), i * 1000);
+        TEST_ASSERT_TRUE(inserted);
+    }
+
+    for (int i = 0; i < 20; i++) {
+        uint8_t mac[6] = {0x00, 0x00, 0x00, 0x00, (uint8_t)(i >> 8), (uint8_t)(i & 0xFF)};
+        ColdRecord* found = tier.lookup(mac);
+        TEST_ASSERT_NOT_NULL(found);
+    }
+}
+
+void test_rapid_insert_remove_cycles(void) {
+    ColdTier tier(64);
+
+    for (int cycle = 0; cycle < 100; cycle++) {
+        uint8_t mac[6] = {
+            (uint8_t)((cycle >> 8) & 0xFF),
+            (uint8_t)(cycle & 0xFF),
+            0x00, 0x00, 0x00, 0x00
+        };
+
+        bool inserted = tier.insert(mac, -70, cycle * 10);
+        TEST_ASSERT_TRUE(inserted);
+
+        ColdRecord* found = tier.lookup(mac);
+        TEST_ASSERT_NOT_NULL(found);
+
+        bool removed = tier.remove(mac);
+        TEST_ASSERT_TRUE(removed);
+
+        found = tier.lookup(mac);
+        TEST_ASSERT_NULL(found);
+    }
+
+    TEST_ASSERT_EQUAL(0, tier.count());
+}
+
+void test_double_remove_no_underflow(void) {
+    // Safety: double-remove should not cause count underflow
+    ColdTier tier(16);
+    uint8_t mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
+    // Insert one record
+    bool inserted = tier.insert(mac, -70, 1000);
+    TEST_ASSERT_TRUE(inserted);
+    TEST_ASSERT_EQUAL(1, tier.count());
+
+    // First remove succeeds
+    bool removed1 = tier.remove(mac);
+    TEST_ASSERT_TRUE(removed1);
+    TEST_ASSERT_EQUAL(0, tier.count());
+
+    // Second remove fails (already tombstoned)
+    bool removed2 = tier.remove(mac);
+    TEST_ASSERT_FALSE(removed2);
+    TEST_ASSERT_EQUAL(0, tier.count());  // Count should not underflow
+}
+
+void test_remove_nonexistent_mac(void) {
+    // Safety: remove on non-existent MAC should not affect count
+    ColdTier tier(16);
+    uint8_t existing[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    uint8_t nonexistent[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
+    // Insert one record
+    tier.insert(existing, -70, 1000);
+    TEST_ASSERT_EQUAL(1, tier.count());
+
+    // Try to remove non-existent MAC
+    bool removed = tier.remove(nonexistent);
+    TEST_ASSERT_FALSE(removed);
+    TEST_ASSERT_EQUAL(1, tier.count());  // Count unchanged
+}
+
+// ============================================================================
+// Test Runner
+// ============================================================================
+
+void setUp(void) {
+    set_mock_heap(100000, 80000);
+}
+
+void tearDown(void) {
+}
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+
+    // ColdRecord
+    RUN_TEST(test_ColdRecord_size_is_24_bytes);
+    RUN_TEST(test_ColdRecord_fields_are_correct_size);
+    RUN_TEST(test_ColdRecord_tombstone_flags);
+    RUN_TEST(test_ColdRecord_rssi_average_no_overflow);
+    RUN_TEST(test_cold_record_can_be_marked_promoted);
+
+    // Hash Function
+    RUN_TEST(test_fnv1a_hash_is_deterministic);
+    RUN_TEST(test_fnv1a_hash_different_for_different_macs);
+
+    // Classifier
+    RUN_TEST(test_classifier_drops_weak_rssi);
+    RUN_TEST(test_classifier_cold_for_moderate_rssi);
+    RUN_TEST(test_classifier_hot_for_known_mac);
+    RUN_TEST(test_classifier_hot_for_ibeacon);
+    RUN_TEST(test_classifier_default_is_cold);
+    RUN_TEST(test_classifier_under_memory_pressure);
+
+    // Cold Tier
+    RUN_TEST(test_cold_tier_insert_and_lookup);
+    RUN_TEST(test_cold_tier_lookup_returns_null_for_missing);
+    RUN_TEST(test_cold_tier_update_existing);
+    RUN_TEST(test_cold_tier_evicts_oldest_when_full);
+    RUN_TEST(test_cold_tier_remove_promoted_record);
+    RUN_TEST(test_cold_tier_remove_nonexistent_returns_false);
+    RUN_TEST(test_cold_tier_update_increments_seen_count);
+    RUN_TEST(test_cold_tier_seen_count_caps_at_255);
+    RUN_TEST(test_rssi_max_tracks_strongest_signal);
+    RUN_TEST(test_promotion_threshold_behavior);
+
+    // Memory Watchdog
+    RUN_TEST(test_watchdog_detects_low_memory);
+    RUN_TEST(test_watchdog_ok_with_sufficient_memory);
+    RUN_TEST(test_watchdog_detects_fragmentation);
+    RUN_TEST(test_watchdog_restart_rate_limited);
+    RUN_TEST(test_watchdog_restart_window_reset);
+    RUN_TEST(test_memory_pressure_transitions);
+    RUN_TEST(test_fragmentation_patterns);
+    RUN_TEST(test_simultaneous_pressure_and_fragmentation);
+
+    // Eviction Scorer
+    RUN_TEST(test_eviction_score_higher_for_included_device);
+    RUN_TEST(test_eviction_score_higher_for_ibeacon);
+    RUN_TEST(test_eviction_score_decays_with_age);
+    RUN_TEST(test_eviction_score_higher_for_closer_device);
+    RUN_TEST(test_eviction_prefers_weak_old_devices);
+
+    // Configuration and Integration
+    RUN_TEST(test_tiered_memory_config_defaults);
+    RUN_TEST(test_backward_compatibility_when_disabled);
+    RUN_TEST(test_cold_tier_enabled_vs_disabled);
+    RUN_TEST(test_manager_classify_respects_enabled_flag);
+    RUN_TEST(test_cold_tier_reports_psram_usage);
+    RUN_TEST(test_manager_cold_tier_accessor);
+
+    // Stress Tests
+    RUN_TEST(test_cold_tier_fill_and_evict_cycle);
+    RUN_TEST(test_cold_tier_tombstone_reuse);
+    RUN_TEST(test_cold_tier_high_collision_scenario);
+    RUN_TEST(test_rapid_insert_remove_cycles);
+
+    // Safety Tests (guard against underflow/invalid state)
+    RUN_TEST(test_double_remove_no_underflow);
+    RUN_TEST(test_remove_nonexistent_mac);
+
+    return UNITY_END();
+}

--- a/test/test_memory_tier/test_memory_tier.cpp
+++ b/test/test_memory_tier/test_memory_tier.cpp
@@ -848,6 +848,42 @@ void test_classifier_strong_rssi_unknown_stays_cold(void) {
     TEST_ASSERT_EQUAL(ClassifyResult::COLD, strong);
 }
 
+void test_weak_device_still_reaches_promotion_threshold(void) {
+    // Multilateration regression: a device heard weakly (but above the -90 drop
+    // floor) must still accumulate sightings toward promotion. Distant nodes read
+    // weak by definition, and a fix needs 3+ nodes reporting — if weak readings
+    // could not promote, every device would collapse to its single nearest node
+    // and never resolve to a position.
+    const uint8_t promotionCount = 5;  // DEFAULT_COLD_PROMOTION_COUNT
+    uint8_t mac[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01};
+    ColdTier cold(64);
+    TEST_ASSERT_TRUE(cold.isEnabled());
+
+    for (int i = 0; i < promotionCount; i++)
+        cold.insert(mac, -88, 1000 + i * 100);  // consistently weak, never close
+
+    ColdRecord *rec = cold.lookup(mac);
+    TEST_ASSERT_NOT_NULL(rec);
+    TEST_ASSERT_GREATER_OR_EQUAL(promotionCount, rec->seenCount);
+}
+
+void test_add_known_mac_is_idempotent(void) {
+    // ConnectToWifi() re-registers known_macs on every settings reload. Without
+    // dedup the 32-entry table fills with duplicates and legitimate later entries
+    // get rejected.
+    uint8_t mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    QuickClassifier classifier;
+
+    for (int i = 0; i < 50; i++)
+        TEST_ASSERT_TRUE(classifier.addKnownMac(mac));
+
+    // Still recognised, and a second distinct MAC still fits (table not exhausted).
+    TEST_ASSERT_EQUAL(ClassifyResult::HOT, classifier.classify(mac, nullptr, 0, -88));
+    uint8_t other[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    TEST_ASSERT_TRUE(classifier.addKnownMac(other));
+    TEST_ASSERT_EQUAL(ClassifyResult::HOT, classifier.classify(other, nullptr, 0, -88));
+}
+
 // ============================================================================
 // Test Runner
 // ============================================================================
@@ -937,6 +973,10 @@ int main(int argc, char **argv) {
     RUN_TEST(test_cold_tier_insert_defaults_idtype_to_misc);
     RUN_TEST(test_cold_tier_insert_upgrades_idtype_on_update);
     RUN_TEST(test_classifier_strong_rssi_unknown_stays_cold);
+
+    // Multilateration coverage (regression: promotion must not gate on RSSI)
+    RUN_TEST(test_weak_device_still_reaches_promotion_threshold);
+    RUN_TEST(test_add_known_mac_is_idempotent);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Re-opens the work from #1998 (reverted during the main-branch reset on 2026-02-08), rebuilt cleanly on top of the subsequent memory-pressure PRs: #2208 slot pool, #2284 lazy-RSSI, #2291 per-chip caps. **Stacks with them, does not replace them.**

Adds a `TieredMemoryManager` / `ColdTier` pre-filter in front of `BleFingerprintCollection::Seen()` that classifies every BLE advertisement BEFORE the slot-pool mutex is taken or a `BleFingerprint` is allocated:

- **DROP**: `rssi < -90` -> return immediately, no mutex, no heap
- **COLD**: unknown MAC -> parked in a 24-byte `ColdRecord` in an open-addressing hash table (PSRAM-preferred, internal SRAM fallback)
- **HOT**: known MAC, iBeacon, or promoted COLD (seen >=5x with `rssi > -75`) -> falls through to existing slot-pool path

Motivation: in BT-saturated environments (30+ devices), #2208's fixed-capacity slot pool fills with transient random-MAC devices and evicts the ones we actually care about. ColdTier shields the pool from that churn.

## What's in the branch

| Commit | What |
|--------|------|
| `d3d468c` | Core `BleMemoryTier.h` (942 lines, self-contained) + 48 native unit tests + integration into `Seen()` |
| `705a019` | Fix MQTT keepalive starvation -- `pub()` no longer blocks up to 250ms retrying; `setKeepAlive(60)`; reset-reason telemetry |
| `0d8e0bd` | **DEBUG**: PSRAM size + tier counters in MQTT telemetry (prunable once stabilised) |
| `d716d01` | Fix MAC pointer UB from `getAddress().getVal()` into a dying temporary (caught in review) |

## PSRAM / per-chip sizing

`DEFAULT_MAX_COLD` lives in `include/defaults.h` and follows the same per-chip pattern #2291 used for `DEFAULT_MAX_FINGERPRINTS`:

- 256 records on `BOARD_HAS_PSRAM`
- 128 on ESP32-S3
- 64 on C3 / C6
- 128 on ESP32 (default)

No `platformio.ini` PSRAM flags added -- `heap_caps_malloc(MALLOC_CAP_SPIRAM)` with `MALLOC_CAP_8BIT` fallback handles it at runtime. Startup logs the chosen backing memory so field diagnosis is at-a-glance.

## Test plan

- [x] `pio test -e native-memory` -- 48/48 passing
- [x] `pio run -e esp32 -e esp32c3 -e esp32s3 -e esp32c6` -- all build clean
- [ ] Flash to a PSRAM node and watch `tierDrop / tierCold / tierHot / tierPromote` counters climb under real BLE load
- [ ] Confirm MQTT keepalive no longer starves during discovery on an S3 node

## Review notes

Ran two independent reviews (quorum-style bug hunter + frontier-model `codereview`) on the diff. Findings:

- **C1 (CRITICAL)** MAC pointer lifetime UB -- fixed in `d716d01`
- **H1 (HIGH)** ColdTier post-eviction insert could theoretically place a record off the probe chain -- after re-analysis, not reachable today because tombstones don't terminate probing (`canStopProbing()` is truly-empty-only) and the off-chain insert only triggers at 100% valid load where there are no truly-empty slots to stop lookup at. Shape is fragile; worth a defensive re-probe in a followup.
- **M3 (MEDIUM)** `pub()` retry loop removed -- deliberate trade-off; keepalive starvation was strictly worse. Callers that MUST retry would need higher-level logic.
- `M1` classifier dead-code for `MIN_RSSI_COLD` -- intentional; promotion is count-based.

## Closes / supersedes

Supersedes #1998 (reverted). Stacks on #2208, #2284, #2291.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tiered memory management system classifying BLE advertisements into HOT/COLD tiers with pre-filtering.
  * Boot reset reason tracking now included in telemetry.
  * Tiered memory metrics (drop, cold, hot, promote counts, capacity, usage) published in telemetry.
  * PSRAM detection and reporting in telemetry.
  * MQTT keep-alive interval configured to 60 seconds.

* **Bug Fixes**
  * MQTT publish simplified from retry loop to single attempt.

* **Tests**
  * Added comprehensive tiered memory management unit test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->