### PR TITLE
fix: return early on xSemaphoreTake failure to prevent heap corruption

### DIFF
--- a/.ast-grep/rules/unguarded-xsemaphoretake.yml
+++ b/.ast-grep/rules/unguarded-xsemaphoretake.yml
@@ -1,0 +1,50 @@
+id: unguarded-xsemaphoretake
+language: cpp
+severity: error
+message: |
+  xSemaphoreTake() failure path must return before touching shared state.
+  Falling through runs the critical section unlocked and then xSemaphoreGive()s
+  a mutex that was never acquired, corrupting FreeRTOS mutex state and any
+  data the mutex was supposed to guard. See git history: bb81432 (#1114),
+  0f6bcc3 (#2127), 10ad32a (#2131) for prior manifestations of this bug class.
+
+note: |
+  Bad:
+    if (xSemaphoreTake(m, MAX_WAIT) != pdTRUE)
+        log_e("failed");         // falls through, no return
+    critical_section();
+    xSemaphoreGive(m);
+
+  Good:
+    if (xSemaphoreTake(m, MAX_WAIT) != pdTRUE) {
+        log_e("failed");
+        return /* safe sentinel */;
+    }
+    critical_section();
+    xSemaphoreGive(m);
+
+  Also OK (explicit documented reason to proceed without lock):
+    if (xSemaphoreTake(m, ...) == pdTRUE) {
+        ...
+        xSemaphoreGive(m);
+    } else {
+        // proceed without lock because <documented invariant>
+        ...
+    }
+
+rule:
+  any:
+    # Pattern A: `if (xSemaphoreTake(...) != pdTRUE) <single-statement>`
+    # where the single statement is NOT a return/break/continue.
+    - all:
+        - pattern: |
+            if (xSemaphoreTake($$$ARGS) != pdTRUE)
+              $BODY
+        - not:
+            has:
+              any:
+                - kind: return_statement
+                - kind: break_statement
+                - kind: continue_statement
+                - kind: goto_statement
+              stopBy: end

--- a/.github/workflows/ast-grep.yml
+++ b/.github/workflows/ast-grep.yml
@@ -1,0 +1,46 @@
+name: ast-grep
+
+# Static analysis for patterns that clang-tidy/flawfinder don't cover well,
+# in particular ESP32/FreeRTOS mutex usage. See .ast-grep/rules/ for the
+# individual rule definitions.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.ino'
+      - '.ast-grep/**'
+      - 'sgconfig.yml'
+      - '.github/workflows/ast-grep.yml'
+  pull_request:
+    paths:
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.ino'
+      - '.ast-grep/**'
+      - 'sgconfig.yml'
+      - '.github/workflows/ast-grep.yml'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ast-grep
+        env:
+          AST_GREP_VERSION: "0.42.1"
+          AST_GREP_SHA256: "5de8b87cba67fc8dc3e239d54b6484802ad745a7ae3de76be4fe89661dc52657"
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/ast-grep.zip \
+            "https://github.com/ast-grep/ast-grep/releases/download/${AST_GREP_VERSION}/app-x86_64-unknown-linux-gnu.zip"
+          echo "${AST_GREP_SHA256}  /tmp/ast-grep.zip" | sha256sum -c -
+          unzip -o /tmp/ast-grep.zip -d /tmp/ast-grep
+          sudo install /tmp/ast-grep/ast-grep /usr/local/bin/ast-grep
+          ast-grep --version
+
+      - name: Scan
+        run: ast-grep scan --config sgconfig.yml src/ lib/

--- a/.github/workflows/ast-grep.yml
+++ b/.github/workflows/ast-grep.yml
@@ -1,0 +1,41 @@
+name: ast-grep
+
+# Static analysis for patterns that clang-tidy/flawfinder don't cover well,
+# in particular ESP32/FreeRTOS mutex usage. See .ast-grep/rules/ for the
+# individual rule definitions.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.ino'
+      - '.ast-grep/**'
+      - 'sgconfig.yml'
+      - '.github/workflows/ast-grep.yml'
+  pull_request:
+    paths:
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.ino'
+      - '.ast-grep/**'
+      - 'sgconfig.yml'
+      - '.github/workflows/ast-grep.yml'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ast-grep
+        run: |
+          curl -fsSL -o /tmp/ast-grep.zip \
+            https://github.com/ast-grep/ast-grep/releases/latest/download/app-x86_64-unknown-linux-gnu.zip
+          unzip -o /tmp/ast-grep.zip -d /tmp/ast-grep
+          sudo install /tmp/ast-grep/ast-grep /usr/local/bin/ast-grep
+          ast-grep --version
+
+      - name: Scan
+        run: ast-grep scan --config sgconfig.yml src/ lib/

--- a/.github/workflows/ast-grep.yml
+++ b/.github/workflows/ast-grep.yml
@@ -30,9 +30,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install ast-grep
+        env:
+          AST_GREP_VERSION: "0.42.1"
+          AST_GREP_SHA256: "5de8b87cba67fc8dc3e239d54b6484802ad745a7ae3de76be4fe89661dc52657"
         run: |
+          set -euo pipefail
           curl -fsSL -o /tmp/ast-grep.zip \
-            https://github.com/ast-grep/ast-grep/releases/latest/download/app-x86_64-unknown-linux-gnu.zip
+            "https://github.com/ast-grep/ast-grep/releases/download/${AST_GREP_VERSION}/app-x86_64-unknown-linux-gnu.zip"
+          echo "${AST_GREP_SHA256}  /tmp/ast-grep.zip" | sha256sum -c -
           unzip -o /tmp/ast-grep.zip -d /tmp/ast-grep
           sudo install /tmp/ast-grep/ast-grep /usr/local/bin/ast-grep
           ast-grep --version

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,2 @@
+ruleDirs:
+  - .ast-grep/rules

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -205,8 +205,10 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
  * @return true if a new configuration was added, false if an existing configuration was replaced.
  */
 bool addOrReplace(DeviceConfig config) {
-    if (xSemaphoreTake(deviceConfigMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(deviceConfigMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take deviceConfigMutex in addOrReplace!");
+        return false;
+    }
 
     std::vector<String> idsToDelete;
     bool isReplacement = false;
@@ -293,8 +295,10 @@ bool Config(String &id, String &json) {
         }
     }
 
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take fingerprintMutex in Config!");
+        return false;
+    }
     for (auto &slot : fingerprints) {
         if (slot.fingerprint == nullptr || slot.pendingDelete)
             continue;
@@ -504,16 +508,20 @@ FingerprintLease GetFingerprint(const NimBLEAdvertisedDevice *advertisedDevice) 
 #else
 FingerprintLease GetFingerprint(BLEAdvertisedDevice *advertisedDevice) {
 #endif
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take semaphore!");
+        return {};
+    }
     auto f = getFingerprintInternal(advertisedDevice);
     xSemaphoreGive(fingerprintMutex);
     return f;
 }
 
 FingerprintLease AcquireNext(size_t &cursor, bool cleanup) {
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take fingerprintMutex!");
+        return {};
+    }
     if (cleanup) CleanupOldFingerprints();
 
     while (cursor < fingerprints.size()) {
@@ -532,8 +540,13 @@ void Release(FingerprintLease &lease) {
     if (!lease)
         return;
 
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take fingerprintMutex!");
+        // Leak the lease rather than touch shared state without the mutex —
+        // the slot's refs stays elevated so the fingerprint isn't freed
+        // from under another reader; acceptable trade-off vs corruption.
+        return;
+    }
 
     if (lease.slot < fingerprints.size()) {
         auto &slot = fingerprints[lease.slot];
@@ -548,8 +561,10 @@ void Release(FingerprintLease &lease) {
 }
 
 size_t Size(bool cleanup) {
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take fingerprintMutex!");
+        return 0;
+    }
     if (cleanup) CleanupOldFingerprints();
     auto count = activeFingerprints;
     xSemaphoreGive(fingerprintMutex);

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -204,8 +204,10 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
  * @return true if a new configuration was added, false if an existing configuration was replaced.
  */
 bool addOrReplace(DeviceConfig config) {
-    if (xSemaphoreTake(deviceConfigMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(deviceConfigMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take deviceConfigMutex in addOrReplace!");
+        return false;
+    }
 
     std::vector<String> idsToDelete;
     bool isReplacement = false;
@@ -292,8 +294,10 @@ bool Config(String &id, String &json) {
         }
     }
 
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take fingerprintMutex in Config!");
+        return false;
+    }
     for (auto &slot : fingerprints) {
         if (slot.fingerprint == nullptr || slot.pendingDelete)
             continue;
@@ -516,16 +520,20 @@ FingerprintLease GetFingerprint(const NimBLEAdvertisedDevice *advertisedDevice) 
 #else
 FingerprintLease GetFingerprint(BLEAdvertisedDevice *advertisedDevice) {
 #endif
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take semaphore!");
+        return {};
+    }
     auto f = getFingerprintInternal(advertisedDevice);
     xSemaphoreGive(fingerprintMutex);
     return f;
 }
 
 FingerprintLease AcquireNext(size_t &cursor, bool cleanup) {
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take fingerprintMutex!");
+        return {};
+    }
     if (cleanup) CleanupOldFingerprints();
 
     while (cursor < fingerprints.size()) {
@@ -544,8 +552,13 @@ void Release(FingerprintLease &lease) {
     if (!lease)
         return;
 
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take fingerprintMutex!");
+        // Leak the lease rather than touch shared state without the mutex —
+        // the slot's refs stays elevated so the fingerprint isn't freed
+        // from under another reader; acceptable trade-off vs corruption.
+        return;
+    }
 
     if (lease.slot < fingerprints.size()) {
         auto &slot = fingerprints[lease.slot];
@@ -560,8 +573,10 @@ void Release(FingerprintLease &lease) {
 }
 
 size_t Size(bool cleanup) {
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
+    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take fingerprintMutex!");
+        return 0;
+    }
     if (cleanup) CleanupOldFingerprints();
     auto count = activeFingerprints;
     xSemaphoreGive(fingerprintMutex);


### PR DESCRIPTION
## Summary

Six sites in `BleFingerprintCollection.cpp` take a FreeRTOS mutex like this:

```cpp
if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE)
    log_e("Couldn't take fingerprintMutex!");
// critical section runs anyway
xSemaphoreGive(fingerprintMutex);
```

When the take times out (`MAX_WAIT = 100ms`, plausible under heavy BLE scan contention where main + scan tasks both hit `fingerprintMutex`), the critical section executes **without the lock**, then `xSemaphoreGive()` is called on a semaphore that was never acquired — corrupting FreeRTOS mutex state and whatever shared structure (`fingerprints[]`, `deviceConfigs`, slot refs) the mutex was guarding. Symptom matches reports of nodes "eventually getting stuck offline" that the internal watchdog fails to recover from.

Six sites fixed:

| Function | Safe return value |
|----------|-------------------|
| `addOrReplace()` | `return false` |
| `Config()` | `return false` |
| `GetFingerprint()` | `return {}` (empty lease) |
| `AcquireNext()` | `return {}` |
| `Release()` | `return` (leak the lease; slot refs stay elevated, acceptable vs corruption) |
| `Size()` | `return 0` |

## Historical context

This class of bug has been fixed in this file before — the new fix follows the shape of prior concurrency fixes:

- #1114 `bb81432` (2023-11-12) "Fix race condition" — introduced 3 of the 6 sites here
- #2127 `0f6bcc3` (2026-02) "Fix crash from unsynchronized fingerprint vector access in scanTask"
- #2131 `10ad32a` (2026-02-26) "Fix unsynchronized fingerprint vector access in Config()"

Three of the six sites have existed since November 2023.

## Static guard against regression

Bundled with the fix: a small `ast-grep` rule (`.ast-grep/rules/unguarded-xsemaphoretake.yml`) and a CI workflow (`.github/workflows/ast-grep.yml`) that flag any future `if (xSemaphoreTake(...) != pdTRUE) <body>` where the body doesn't contain a `return` / `break` / `continue` / `goto`.

Validated:
- Against `origin/main` before this PR: **6 violations flagged** (lines 208, 296, 507, 515, 535, 551 — exactly the 6 sites)
- Against this branch: **0 violations**

## Test plan

- [x] `pio run -e esp32` — builds clean
- [x] ast-grep scan on origin/main: 6 violations
- [x] ast-grep scan on this branch: 0 violations
- [ ] Flash to a device-dense node and confirm stuck-offline symptoms resolve (in progress — found during review of #2313, which stacks on this)

## Why this is its own PR

Caught during review of #2313 (tiered memory). Separating because:
1. The fix is valuable independent of the tiered memory feature
2. It matches the pattern of prior small concurrency fixes (#2127, #2131)
3. Stuck-offline symptoms may be driven primarily by this bug, not by OOM pressure

Will rebase #2313 on top of this once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a static-analysis rule to detect unsafe semaphore take patterns that can lead to fall-through without the required lock.
* **Bug Fixes**
  * Improved mutex-failure handling in Bluetooth fingerprint operations by exiting early (returning failure/empty results) to prevent unsafe access to shared state.
  * Adjusted release behavior to avoid modifying the provided lease when synchronization cannot be acquired.
* **Chores**
  * Enabled automated ast-grep scanning in CI and configured it to load rules from the project’s rule directory on relevant code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->