### PR TITLE
Resolve MQTT broker hostname via mDNS

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -248,6 +248,9 @@ void setupNetwork() {
     if (!MultiNetwork.connect(ethernetType, 20, wifiTimeout, HeadlessWiFiSettings.hostname.c_str()))
         ESP.restart();
 
+    if (!MDNS.begin(HeadlessWiFiSettings.hostname.c_str()))
+        Log.println("Error starting mDNS responder");
+
     GUI::Connected(true, false);
 
 #ifdef FIRMWARE
@@ -459,7 +462,23 @@ void connectToMqtt() {
     mqttClient.onDisconnect(onMqttDisconnect);
     mqttClient.onMessage(onMqttMessageRaw);
     mqttClient.setClientId(HeadlessWiFiSettings.hostname.c_str());
-    mqttClient.setServer(mqttHost.c_str(), mqttPort);
+
+    String hostLower = mqttHost;
+    hostLower.toLowerCase();
+    int dotLocal = hostLower.indexOf(".local");
+    if (dotLocal > 0) hostLower.remove(dotLocal);
+    if (hostLower.length() > 0 && hostLower.indexOf('.') < 0) {
+        IPAddress mqttIP = MDNS.queryHost(hostLower.c_str());
+        if (mqttIP != IPAddress()) {
+            Log.printf("Resolved %s via mDNS to %s\r\n", mqttHost.c_str(), mqttIP.toString().c_str());
+            mqttClient.setServer(mqttIP, mqttPort);
+        } else {
+            Log.printf("mDNS lookup failed for %s, using string\r\n", mqttHost.c_str());
+            mqttClient.setServer(mqttHost.c_str(), mqttPort);
+        }
+    } else {
+        mqttClient.setServer(mqttHost.c_str(), mqttPort);
+    }
     mqttClient.setWill(statusTopic.c_str(), 0, true, "offline");
     mqttClient.setCredentials(mqttUser.c_str(), mqttPass.c_str());
     mqttClient.connect();

--- a/src/main.h
+++ b/src/main.h
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <AsyncTCP.h>
+#include <ESPmDNS.h>
 #include <HeadlessWiFiSettings.h>
 #include <ESPAsyncWebServer.h>
 #include <HTTPClient.h>


### PR DESCRIPTION
## Summary
- Initialize `MDNS` after the network comes up so `.local` lookups work.
- In `connectToMqtt()`, if `mqtt_host` is a single-label hostname (e.g. `homeassistant`) or ends in `.local`, resolve it via `MDNS.queryHost()` before handing it to `mqttClient.setServer()`. Falls back to the raw string when mDNS doesn't return a hit, so existing IP / FQDN configurations are untouched.

Inspired by [wled/WLED#4769](https://github.com/wled/WLED/pull/4769) — same idea, same fallback behavior.

## Test plan
- [ ] Set `mqtt_host` to `homeassistant.local` and confirm broker connects (mDNS resolves on local LAN).
- [ ] Set `mqtt_host` to `homeassistant` (no domain) and confirm broker connects.
- [ ] Set `mqtt_host` to a raw IP and confirm no behavioral change.
- [ ] Set `mqtt_host` to a fully-qualified DNS name (e.g. `mqtt.example.com`) and confirm regular DNS path is used.
- [ ] Verify serial log prints either `Resolved ... via mDNS to <ip>` or `mDNS lookup failed for ..., using string` on the right paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mDNS support for MQTT server discovery, enabling automatic hostname resolution on local networks without requiring fully qualified domain names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->