### PR TITLE
fix: add NimBLE 2.x onSubscribe callback signature in Enrollment

### DIFF
--- a/src/Enrollment.cpp
+++ b/src/Enrollment.cpp
@@ -165,6 +165,25 @@ class CharacteristicCallbacks : public NimBLECharacteristicCallbacks {
      * @param desc Pointer to the GAP connection descriptor for the client (provides conn_handle and peer address).
      * @param subValue Subscription value where `0` = unsubscribed, `1` = notifications, `2` = indications, `3` = notifications and indications.
      */
+#ifdef NIMBLE_V2
+    void onSubscribe(NimBLECharacteristic *pCharacteristic, NimBLEConnInfo &connInfo, uint16_t subValue) override {
+        String str = "Client ID: ";
+        str += connInfo.getConnHandle();
+        str += " Address: ";
+        str += connInfo.getAddress().toString().c_str();
+        if (subValue == 0) {
+            str += " Unsubscribed to ";
+        } else if (subValue == 1) {
+            str += " Subscribed to notfications for ";
+        } else if (subValue == 2) {
+            str += " Subscribed to indications for ";
+        } else if (subValue == 3) {
+            str += " Subscribed to notifications and indications for ";
+        }
+        str += std::string(pCharacteristic->getUUID()).c_str();
+        Log.println(str);
+    };
+#else
     void onSubscribe(NimBLECharacteristic *pCharacteristic, ble_gap_conn_desc *desc, uint16_t subValue) {
         String str = "Client ID: ";
         str += desc->conn_handle;
@@ -182,6 +201,7 @@ class CharacteristicCallbacks : public NimBLECharacteristicCallbacks {
         str += std::string(pCharacteristic->getUUID()).c_str();
         Log.println(str);
     };
+#endif
 };
 
 class DescriptorCallbacks : public NimBLEDescriptorCallbacks {


### PR DESCRIPTION
## Summary
- On esp32c6/esp32s3 the env links NimBLE-Arduino 2.x, where `NimBLECharacteristicCallbacks::onSubscribe` takes `NimBLEConnInfo&` instead of `ble_gap_conn_desc*`.
- The existing v1-only `onSubscribe` never overrode the base virtual on those targets, so client subscribe/unsubscribe logging was silently dead.
- Adds a `#ifdef NIMBLE_V2` branch with the 2.x signature (uses `getConnHandle()` / `getAddress().toString()`), mirroring the existing `onStatus` guard in the same class. The v1 path is unchanged under `#else`.

This is a follow-up to the same NimBLE-2.x callback gap that #2366 fixes for the `ServerCallbacks`, but for the `CharacteristicCallbacks::onSubscribe` method. Independent of #2366 (different method, different lines).

## Test plan
- [x] `pio run -e esp32c6` succeeds (the `override` keyword fails the build if the v2 signature is wrong)
- [ ] HIL pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth connection event handling and logging for subscription notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ESPresense/ESPresense/pull/2369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->