### PR TITLE
qa: HIL post-flash boot-loop watchdog for #2244

### DIFF
--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -41,6 +41,7 @@ steps:
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          python3 ./tools/hil/check_no_bootloop.py --port $DEVICE --window 30 --log-out /tmp/${FIRMWARE_ENV}-bootlog.txt
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -79,6 +80,7 @@ steps:
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          python3 ./tools/hil/check_no_bootloop.py --port $DEVICE --window 30 --log-out /tmp/${FIRMWARE_ENV}-bootlog.txt
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -118,6 +120,7 @@ steps:
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          python3 ./tools/hil/check_no_bootloop.py --port $DEVICE --window 30 --log-out /tmp/${FIRMWARE_ENV}-bootlog.txt
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -156,6 +159,7 @@ steps:
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          python3 ./tools/hil/check_no_bootloop.py --port $DEVICE --window 30 --log-out /tmp/${FIRMWARE_ENV}-bootlog.txt
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '

--- a/tools/hil/.gitignore
+++ b/tools/hil/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tools/hil/README.md
+++ b/tools/hil/README.md
@@ -1,0 +1,44 @@
+# HIL helper scripts
+
+Auxiliary scripts that run alongside the firmware-tester image in
+[`.woodpecker/hil.yml`](../../.woodpecker/hil.yml). The firmware-tester image
+itself ships the long-running monitor (`/scripts/hil_monitor.py`) and the
+WiFi-provisioning helper (`/scripts/improv_wifi.py`); scripts here are
+ESPresense-repo-local extensions that run before those, against the same
+serial device.
+
+## `check_no_bootloop.py`
+
+Fast post-flash boot-loop watchdog. Reproduces issue
+[#2244](https://github.com/ESPresense/ESPresense/issues/2244) ("ESP32-C3
+boot loop after app entry on ESPresense C3 builds").
+
+After `pio run -t upload`, this script captures ~30s of serial output and
+fails fast if it sees:
+
+- Any panic / Guru Meditation / Backtrace / `abort()` report.
+- Two or more ROM bootloader `rst:` lines in the window (= the device
+  rebooted more than once after the post-upload reset).
+- Three or more bootloader entry headers (defense in depth against firmware
+  that crashes before any panic line is printed).
+
+A failure aborts the rest of the HIL pipeline (`improv_wifi.py`,
+`hil_monitor.py`) for that board so the duration budget isn't burned on a
+build that is known to be broken, and the captured log is dumped to stdout
+plus written to `/tmp/${FIRMWARE_ENV}-bootlog.txt` for forensic upload.
+
+### Run locally
+
+```sh
+python3 tools/hil/check_no_bootloop.py --port /dev/ttyUSB0 --window 30
+```
+
+### Tests
+
+```sh
+python3 tools/hil/test_check_no_bootloop.py
+```
+
+The unit tests cover the heuristic over canned serial captures (healthy
+boot, the literal #2244 boot-loop trace, panic with backtrace, Guru
+Meditation). They don't touch a serial device.

--- a/tools/hil/check_no_bootloop.py
+++ b/tools/hil/check_no_bootloop.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Post-flash boot-loop watchdog for HIL runs.
+
+Reproduces issue #2244 ("ESP32-C3-DevKitM-1-N4X boot loop after app entry on
+ESPresense C3 builds"). After ``pio run -t upload`` flashes a board, this
+script captures serial output for a short window and fails fast if it sees
+any of the following bug-class signatures:
+
+- A panic / Guru Meditation / Backtrace / abort() report.
+- Two or more ROM bootloader ``rst:`` lines (i.e., the device reset more than
+  once during the window — a reboot loop).
+- Three or more bootloader entry headers (defense in depth against firmware
+  that crashes before any panic is printed).
+
+If any signature is hit, the script writes the captured log to stderr and
+exits non-zero, so the rest of the HIL pipeline (improv-wifi pairing, full
+``hil_monitor.py`` run) never executes against a known-broken build.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+from dataclasses import dataclass
+
+try:
+    import serial  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover -- pyserial is in the firmware-tester image
+    print("pyserial is required (the firmware-tester image already has it)", file=sys.stderr)
+    sys.exit(2)
+
+RST_PATTERN = re.compile(rb"rst:0x[0-9A-Fa-f]+")
+BOOT_HEADER_PATTERN = re.compile(rb"ets [A-Z][a-z]+\s+\d+\s+\d{4}")
+PANIC_PATTERNS: tuple[tuple[str, re.Pattern[bytes]], ...] = (
+    ("guru-meditation", re.compile(rb"Guru Meditation Error")),
+    ("backtrace", re.compile(rb"Backtrace:")),
+    ("abort", re.compile(rb"abort\(\) was called at PC")),
+    ("panic", re.compile(rb"Core\s+\d+\s+panic'?ed", re.IGNORECASE)),
+    ("assert", re.compile(rb"assert failed:")),
+)
+
+
+@dataclass
+class Verdict:
+    failed: bool = False
+    reasons: list[str] = None  # type: ignore[assignment]
+    rst_count: int = 0
+    boot_header_count: int = 0
+
+    def __post_init__(self) -> None:
+        if self.reasons is None:
+            self.reasons = []
+
+
+def evaluate(buffer: bytes, *, max_rst: int, max_boot_headers: int) -> Verdict:
+    verdict = Verdict()
+    verdict.rst_count = len(RST_PATTERN.findall(buffer))
+    verdict.boot_header_count = len(BOOT_HEADER_PATTERN.findall(buffer))
+
+    for label, pattern in PANIC_PATTERNS:
+        if pattern.search(buffer):
+            verdict.reasons.append(label)
+            verdict.failed = True
+
+    if verdict.rst_count > max_rst:
+        verdict.reasons.append(f"reboot-loop ({verdict.rst_count} rst: lines, > {max_rst})")
+        verdict.failed = True
+
+    if verdict.boot_header_count > max_boot_headers:
+        verdict.reasons.append(
+            f"reboot-loop ({verdict.boot_header_count} boot headers, > {max_boot_headers})"
+        )
+        verdict.failed = True
+
+    return verdict
+
+
+def capture(port: str, baud: int, window_secs: float) -> bytes:
+    chunks: list[bytes] = []
+    deadline = time.monotonic() + window_secs
+    with serial.Serial(port, baud, timeout=0.5) as ser:
+        # Toggle DTR to force a clean reset so we see the ROM bootloader output.
+        # Some boards land here already-running from the post-upload reset; the
+        # toggle is harmless on those.
+        try:
+            ser.setDTR(False)
+            ser.setRTS(False)
+            time.sleep(0.1)
+            ser.setDTR(True)
+            ser.setRTS(True)
+        except Exception:  # noqa: BLE001 -- not all USB-serial bridges support this
+            pass
+
+        while time.monotonic() < deadline:
+            data = ser.read(4096)
+            if data:
+                chunks.append(data)
+    return b"".join(chunks)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--port", required=True, help="Serial device to monitor (e.g. /dev/esp32c3)")
+    parser.add_argument("--baud", type=int, default=115200)
+    parser.add_argument("--window", type=float, default=30.0, help="Capture window seconds (default: 30)")
+    parser.add_argument(
+        "--max-rst",
+        type=int,
+        default=1,
+        help="Allowed rst: count in window (default: 1, the post-upload reset)",
+    )
+    parser.add_argument(
+        "--max-boot-headers",
+        type=int,
+        default=2,
+        help="Allowed bootloader entry headers in window (default: 2)",
+    )
+    parser.add_argument(
+        "--log-out",
+        help="Optional path to write the raw captured serial bytes for forensic upload",
+    )
+    args = parser.parse_args(argv)
+
+    print(f"check_no_bootloop: capturing {args.window}s of serial from {args.port} at {args.baud} baud", flush=True)
+    try:
+        buffer = capture(args.port, args.baud, args.window)
+    except serial.SerialException as exc:
+        print(f"check_no_bootloop: serial error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.log_out:
+        try:
+            with open(args.log_out, "wb") as fh:
+                fh.write(buffer)
+        except OSError as exc:
+            print(f"check_no_bootloop: could not write log to {args.log_out}: {exc}", file=sys.stderr)
+
+    verdict = evaluate(
+        buffer,
+        max_rst=args.max_rst,
+        max_boot_headers=args.max_boot_headers,
+    )
+
+    text = buffer.decode("utf-8", errors="replace")
+    print("---- captured serial ----")
+    print(text)
+    print("---- end captured serial ----")
+    print(
+        f"check_no_bootloop: rst={verdict.rst_count} boot_headers={verdict.boot_header_count}",
+        flush=True,
+    )
+
+    if verdict.failed:
+        print(
+            f"check_no_bootloop: FAIL — {', '.join(verdict.reasons)}",
+            file=sys.stderr,
+        )
+        print(
+            "check_no_bootloop: see https://github.com/ESPresense/ESPresense/issues/2244",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("check_no_bootloop: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/hil/test_check_no_bootloop.py
+++ b/tools/hil/test_check_no_bootloop.py
@@ -1,0 +1,87 @@
+"""Offline tests for the boot-loop signature evaluator.
+
+The ``capture`` step is excluded from these tests because it requires a real
+serial device; the heuristic in ``evaluate`` is what determines pass/fail and
+is the load-bearing part to lock down.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from check_no_bootloop import evaluate  # noqa: E402
+
+
+HEALTHY_BOOT = b"""
+ets Jul 29 2019 12:21:46
+rst:0x1 (POWERON_RESET)
+configsip: 0
+SPIWP:0xee
+clk_drv:0x00,q_drv:0x00
+mode:DIO, clock div:1
+load:0x3fff0030,len:0x6f4
+entry 0x40080638
+ESPresense booted, IP=10.0.0.42
+"""
+
+C3_BOOTLOOP = b"""
+ets Jul 29 2019 12:21:46
+rst:0x1 (POWERON_RESET)
+entry 0x403823ac
+SHA-256 comparison failed.
+rst:0x7 (TG0WDT_SYS_RST)
+ets Jul 29 2019 12:21:46
+rst:0x10 (RTCWDT_RTC_RST)
+ets Jul 29 2019 12:21:46
+"""
+
+PANIC = b"""
+ets Jul 29 2019 12:21:46
+rst:0x1 (POWERON_RESET)
+abort() was called at PC 0x40080638 on core 0
+Backtrace: 0x40080638:0x3ffb0080 0x4008063b:0x3ffb00a0
+"""
+
+GURU = b"""
+ets Jul 29 2019 12:21:46
+rst:0x1 (POWERON_RESET)
+Guru Meditation Error: Core 0 panic'ed (Unhandled debug exception).
+"""
+
+
+class EvaluateTests(unittest.TestCase):
+    def test_healthy_boot(self) -> None:
+        v = evaluate(HEALTHY_BOOT, max_rst=1, max_boot_headers=2)
+        self.assertFalse(v.failed)
+        self.assertEqual(v.rst_count, 1)
+        self.assertEqual(v.boot_header_count, 1)
+
+    def test_c3_bootloop(self) -> None:
+        v = evaluate(C3_BOOTLOOP, max_rst=1, max_boot_headers=2)
+        self.assertTrue(v.failed)
+        self.assertGreaterEqual(v.rst_count, 3)
+        self.assertTrue(any("reboot-loop" in r for r in v.reasons))
+
+    def test_panic_with_backtrace(self) -> None:
+        v = evaluate(PANIC, max_rst=1, max_boot_headers=2)
+        self.assertTrue(v.failed)
+        self.assertIn("backtrace", v.reasons)
+        self.assertIn("abort", v.reasons)
+
+    def test_guru_meditation(self) -> None:
+        v = evaluate(GURU, max_rst=1, max_boot_headers=2)
+        self.assertTrue(v.failed)
+        self.assertIn("guru-meditation", v.reasons)
+        self.assertIn("panic", v.reasons)
+
+    def test_threshold_overrides(self) -> None:
+        # If a board is allowed to reboot once on first boot (rare), a more
+        # permissive threshold lets it pass.
+        v = evaluate(C3_BOOTLOOP, max_rst=10, max_boot_headers=10)
+        self.assertFalse(v.failed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a CI-detectable repro for [#2244 — "ESP32-C3 boot loop after app entry"](https://github.com/ESPresense/ESPresense/issues/2244). Failing-test-style regression guard; runs in the existing HIL pipeline.

New `tools/hil/check_no_bootloop.py` runs in `.woodpecker/hil.yml` immediately after `pio run -t upload` for all four PR-blocking and nightly boards (esp32, esp32c3, esp32c6, esp32s3). Fails fast (within ~30s) on:

- panic / Guru Meditation / Backtrace / `abort()` report
- two or more ROM bootloader `rst:` lines in the window
- three or more bootloader entry headers (catches firmware that crashes before printing a panic line)

When a failure is detected, the rest of the HIL pipeline (improv_wifi pairing, hil_monitor) is aborted so the duration budget isn't burned on a known-broken build, and the captured log is dumped to stdout plus written to `/tmp/${FIRMWARE_ENV}-bootlog.txt`.

The exact board on #2244 (ESP32-C3-DevKitM-1-N4X) is not in the rack today, so this watchdog cannot reproduce that specific failure right now. It WILL catch any boot-loop regression on the boards we do test, within ~30s instead of burning the full 180s/28800s monitor window.

Refs: ESPA-23.

> **Note:** split from #2320 per "one PR per issue" — manifest-check (#2225) stays on #2320, this PR carries only the #2244 watchdog.

## Test plan

- [x] `python3 tools/hil/test_check_no_bootloop.py` (offline heuristic unit tests, 5/5 pass: healthy boot, C3 boot-loop trace from #2244, panic+backtrace, Guru Meditation, threshold overrides)
- [ ] HIL pipeline round-trip on real hardware — exercised on first PR-event run in Woodpecker. The watchdog is purely additive; if it passes, `improv_wifi.py` and `hil_monitor.py` proceed exactly as before.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated bootloop verification to the test pipeline that captures and analyzes device output after firmware upload, aborting pipeline steps on detected stability issues.

* **Documentation**
  * Added documentation for the bootloop verification tool including local usage instructions.

* **Tests**
  * Added unit tests for bootloop detection with various firmware scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ESPresense/ESPresense/pull/2370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->