### PR TITLE
docs: answer "how accurate is ESPresense?" with a pointer to the canonical baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ An ESP32 based presence detection node for use with the [Home Assistant](https:/
 **Building:** [building](./BUILDING.md).
 
 **Release Notes:** [changelog](./CHANGELOG.md).
+
+**Accuracy:** [how accurate is ESPresense?](./docs/accuracy.md)
 # trigger CI

--- a/docs/accuracy.md
+++ b/docs/accuracy.md
@@ -1,0 +1,57 @@
+# How accurate is ESPresense?
+
+**Short answer (v1 baseline, June 2026):** on a tier-1 4-node ESP32 setup in a
+6m × 4m two-room floor, simulated positioning lands at a **median error of
+~0.60m** and **p95 of ~1.3–1.6m**, using the real Companion `ILocate`
+solver. Room mis-identification is **~6.6%** in normal walking and rises near
+room boundaries (by design — see the canonical doc).
+
+> These figures are a **frozen snapshot** of the first published baseline, kept
+> here so the firmware repo answers the "how accurate is this?" question
+> directly. They are **not** the live source of truth and may lag. For the
+> current numbers, the full methodology, the regression-tested CI guard, and
+> the documented blind spots, always cite the canonical baseline:
+>
+> **→ [ESPresense-companion `docs/accuracy.md`](https://github.com/ESPresense/ESPresense-companion/blob/main/docs/accuracy.md)**
+
+## Why accuracy lives in the Companion repo, not here
+
+The firmware on each ESP32 node measures **distance** to a Bluetooth device
+(RSSI → meters via the log-distance formula) and publishes it over MQTT. It
+does **not** compute position. Trilateration — turning several nodes' distance
+streams into an (x, y) location and a room assignment — runs in the
+[ESPresense-companion](https://github.com/ESPresense/ESPresense-companion) app's
+`ILocate` implementations (`NelderMead`, `GaussNewton`, `BFGS`, `MLE`).
+
+Positioning accuracy is therefore measured and published where the positioning
+code actually lives. The accuracy harness drives the **real** `ILocate` against
+seeded, reproducible scenarios and commits a versioned baseline; a CI guard
+re-runs it on every PR that touches the locator code path and fails on drift
+outside a ±5% tolerance.
+
+## What the firmware repo *does* own
+
+The piece of the accuracy chain that lives here is the **RSSI → distance**
+conversion (`d = 10^((P0 - RSSI) / (10 · n))`):
+
+- `src/BleFingerprint.cpp` — applies the log-distance formula per fingerprint.
+- `lib/filtering/AdaptivePercentileRSSI.cpp` — RSSI smoothing and the
+  `getDistanceVariance` path that feeds it.
+
+A host-side (`native`) unit-test suite with known-distance fixtures for this
+conversion is being added under `test/`; see
+[#2317](https://github.com/ESPresense/ESPresense/pull/2317).
+
+If the distance numbers a node reports are wrong, that is a firmware bug and
+belongs to the fixtures above. If the *position* is wrong while the distances
+are stable (e.g.
+[#1817](https://github.com/ESPresense/ESPresense/issues/1817)), that is a
+locator-side concern measured by the Companion harness above.
+
+## Blind spots (v1)
+
+The baseline is **simulated, not measured on hardware**. It deliberately does
+not yet model real RF, per-board RSSI variance across tier-1 variants, or
+inter-sample smoothing. The full, current list of limitations lives in the
+[canonical doc](https://github.com/ESPresense/ESPresense-companion/blob/main/docs/accuracy.md#what-this-baseline-does-not-model-blind-spots).
+Real-hardware-in-the-loop measurements will follow in the same report format.


### PR DESCRIPTION
## What

Adds `docs/accuracy.md` to the firmware repo and a one-line **Accuracy** link in the README, so the flagship repo finally answers *"how accurate is ESPresense?"* — the question the project has never had a public answer to.

The substantive baseline work landed Companion-side in **[ESPresense-companion#1582](https://github.com/ESPresense/ESPresense-companion/pull/1582)** (merged), which runs the **real** `ILocate` harness and publishes the first citable numbers. This PR is purely the **discoverability bridge** from the firmware repo to that canonical doc.

## Why not just put the numbers here

Per your steer on [#2318](https://github.com/ESPresense/ESPresense/pull/2318): the firmware repo doesn't trilaterate, so a firmware-side accuracy *number* measures code that ships nowhere and will drift from the source of truth. This doc therefore:

- duplicates **no live numbers** — it carries only a clearly-labelled, dated **frozen v1 snapshot** (median ~0.60m / p95 ~1.3–1.6m) and links out for current figures;
- explains the firmware/Companion split (firmware emits per-station distance; trilateration runs in Companion's `ILocate`);
- scopes what the firmware repo *does* own in the accuracy chain — the RSSI→distance formula in `src/BleFingerprint.cpp` / `lib/filtering/AdaptivePercentileRSSI.cpp`, with the native fixture suite tracked in #2317.

## Files

- `docs/accuracy.md` — new, ~58 lines, pointer + frozen snapshot + blind-spots note.
- `README.md` — one line under the existing Building / Release Notes links.

Docs-only; no code or CI changes. Canonical source of truth stays the Companion `docs/accuracy.md`.

Closes the firmware-repo half of ESPA-21.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * Added accuracy metrics documentation including positioning error rates and measurement methodology
  * Published v1 baseline accuracy snapshot with known limitations and performance data
  * Updated README with new Accuracy reference link

<!-- end of auto-generated comment: release notes by coderabbit.ai -->