### PR TITLE
deleteAllBonds after init

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -554,6 +554,7 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
 
 void scanTask(void *parameter) {
     NimBLEDevice::init("ESPresense");
+    NimBLEDevice::deleteAllBonds();
     Enrollment::Setup();
     NimBLEDevice::setMTU(23);
 


### PR DESCRIPTION
after completing enrollment, the node where I connected to will continue to see my devices permanent mac address causing it to not correctly track my phone by its IRK... 

Ideally this would be cleared after enrollment is complete, but I can't get that working (I only tried briefly).. and since you already need to reboot the node to clear the current enrollment state, this should be good enough 🤷‍♂️ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bluetooth pairing data is now cleared during app initialization before BLE scanning starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->