### PR TITLE
docs(ui): name HTU21D/Si7021 in SHT sensor label

### DIFF
--- a/ui/src/routes/hardware/+page.svelte
+++ b/ui/src/routes/hardware/+page.svelte
@@ -642,7 +642,7 @@
                 <input name="BMP280_I2c" bind:value={$hardwareSettings.values['BMP280_I2c']}/>
             </label>
         </p>
-        <h4>SHTC1/3, SHTW1/2, SHT3x/4x, SHT85 - Temperature and Humidity Sensor:</h4>
+        <h4>SHTC1/3, SHTW1/2, SHT2x/3x/4x, SHT85, HTU21D, Si7021 (GY-21) - Temperature and Humidity Sensor:</h4>
         <p>
             <label>
                 I2C Bus (-1 to disable):<br />


### PR DESCRIPTION
HTU21D is already supported — it just isn't discoverable.

`arduino-sht`'s `AUTO_DETECT` probes `SHT2X`, and that driver is protocol-identical to the HTU21D:

| | arduino-sht `SHT2xSensor` | HTU21D datasheet |
|---|---|---|
| I2C address | `0x40` | `0x40` |
| Commands | `0xF3` / `0xF5` (no-hold) | `0xF3` / `0xF5` |
| CRC | CRC-8 poly 0x31, init 0 | same |
| Temp | `-46.85 + 175.72 · x/65536` | same |
| RH | `-6 + 125 · x/65536` | same |
| Status bit | LSB bit 1 = measurement type | same |

This matches the field report in #100, where a GY-21 module worked by setting `SHT_I2c_Bus` with no code changes.

So the only fix needed is the label. Supersedes #2056 (88 LOC + an `Adafruit_HTU21DF` dependency for a sensor the existing driver already reads).

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jSdYEekujRETaQBZvYycy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the I2C temperature and humidity sensor section to list support for SHT2x/3x/4x, HTU21D, and Si7021 (GY-21) sensors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->