### PR TITLE
fix: distinguish addOrReplace lock failure from replacement

### DIFF
--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -194,6 +194,12 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
     if (onSeen) onSeen(false);
 }
 
+enum class AddOrReplaceResult {
+    Failed,
+    Added,
+    Replaced,
+};
+
 /**
  * @brief Add a device configuration or replace an existing one with the same id.
  *
@@ -201,12 +207,13 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
  * are removed and their ids are scheduled for deletion (deletion occurs after the function returns).
  *
  * @param config DeviceConfig to add or use to replace an existing entry with the same `id`.
- * @return true if a new configuration was added, false if an existing configuration was replaced.
+ * @return Added for a new config, Replaced when an existing config was updated, Failed if the mutex
+ *         could not be acquired (shared state left unchanged).
  */
-bool addOrReplace(DeviceConfig config) {
+AddOrReplaceResult addOrReplace(DeviceConfig config) {
     if (xSemaphoreTake(deviceConfigMutex, MAX_WAIT) != pdTRUE) {
         log_e("Couldn't take deviceConfigMutex in addOrReplace!");
-        return false;
+        return AddOrReplaceResult::Failed;
     }
 
     std::vector<String> idsToDelete;
@@ -242,7 +249,7 @@ bool addOrReplace(DeviceConfig config) {
         deleteConfig(id);
     }
 
-    return !isReplacement;
+    return isReplacement ? AddOrReplaceResult::Replaced : AddOrReplaceResult::Added;
 }
 
 bool removeConfig(const String &id) {
@@ -281,9 +288,11 @@ bool Config(String &id, String &json) {
         config.name = doc["name"].as<String>();
     if (doc.containsKey("connect") && doc["connect"].is<bool>())
         config.allowConnect = doc["connect"].as<bool>();
-    auto isNew = addOrReplace(config);
+    auto result = addOrReplace(config);
+    if (result == AddOrReplaceResult::Failed)
+        return false;
 
-    if (isNew) {
+    if (result == AddOrReplaceResult::Added) {
         auto p = id.indexOf("irk:");
         if (p == 0) {
             auto irk_hex = id.substring(4);


### PR DESCRIPTION
## Summary
Follow-up to #2314 / CodeRabbit feedback.

`addOrReplace()` used to return `false` for both:
1. successful replacement of an existing config
2. failure to take `deviceConfigMutex`

`Config()` treated `false` as “not new” and continued, so a lock timeout could look like a normal replace and still return success without the config being persisted.

## Change
- `addOrReplace()` now returns `Added | Replaced | Failed`
- `Config()` returns `false` immediately on `Failed`
- IRK registration still only happens on `Added`

## Test plan
- [x] Diff review of sole caller (`Config`)
- [ ] CI firmware builds
- [ ] Optional: set device config over MQTT/UI under load and confirm failures don’t report success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when Bluetooth fingerprint configurations cannot be saved.
  * Prevented unnecessary identity-key processing when updating an existing configuration.
  * More accurately distinguishes between newly added and replaced configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->