### PR TITLE
fix: /json double-send leak and low-heap reboot (#2309)

### DIFF
--- a/src/HttpWebServer.cpp
+++ b/src/HttpWebServer.cpp
@@ -60,7 +60,10 @@ void serializeDevices(JsonObject &root, bool showAll) {
 bool servingJson = false;
 
 void serveJson(AsyncWebServerRequest *request) {
-    if (servingJson) request->send(429, "Too Many Requests", "Too Many Requests");
+    if (servingJson) {
+        request->send(429, "Too Many Requests", "Too Many Requests");
+        return;  // without this we send twice and leak the first response, plus a second 12KB buffer
+    }
     servingJson = true;
     bool showAll = false;
     const String &url = request->url();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -680,6 +680,19 @@ void loop() {
         auto freeHeap = ESP.getFreeHeap();
         if (freeHeap < 20000) Log.printf("Low memory: %lu bytes free\r\n", static_cast<unsigned long>(freeHeap));
         if (freeHeap > 40000) Updater::Loop();
+
+        // ponytail: watchdog, not a leak fix. A heap-starved node limps forever (mqtt and
+        // telemetry both fail, nothing recovers), so reboot after 60s stuck below the
+        // threshold mqtt already refuses to publish under. Same escape hatch as the stuck
+        // BLE controller restart in BleFingerprintCollection::CleanupOldFingerprints().
+        static uint8_t lowHeapPasses = 0;
+        if (freeHeap < MQTT_MIN_FREE_MEMORY) {
+            if (++lowHeapPasses >= 12) {
+                Log.printf("Out of memory for 60s (%lu bytes free), restarting\r\n", static_cast<unsigned long>(freeHeap));
+                ESP.restart();
+            }
+        } else
+            lowHeapPasses = 0;
     }
     GUI::Loop();
     Motion::Loop();


### PR DESCRIPTION
Two small, independent fixes for #2309.

### 1. `serveJson()` was missing a `return`

```cpp
if (servingJson) request->send(429, "Too Many Requests", "Too Many Requests");
servingJson = true;
```

On an overlapping `/json` request this sent the 429 and then fell through: `request->send()` gets called a second time (`AsyncWebServerRequest::send()` overwrites `_response` without freeing the previous one, so the 429 object leaks), and a second `AsyncJsonResponse(false, JSON_BUFFER_SIZE)` — 12 KB — gets allocated.

A 24 KB transient spike on a node with ~100 KB free is exactly the shape of the `heap_caps_malloc_prefer failed to allocate 2312 bytes` errors in that issue, and it matches the reporter's own observation that memory drains faster with the web UI left open.

### 2. Reboot after 60 s stuck below `MQTT_MIN_FREE_MEMORY`

Today a heap-starved node limps forever — mqtt and telemetry both fail, HA sees a stale node, nothing recovers. This turns the reported "freeze" into a restart, using the same escape hatch as the stuck-BLE-controller restart in `CleanupOldFingerprints()`. It's a watchdog, not a leak fix.

### What this is *not*

It is not a fix for the slow heap decline in #2309. That decline is present in v4.0.6 too per the reporter, so it is not a v4.1.0 regression, and the earlier root-cause claims in that thread (PR #2208/#2284, per-chip OOM guard constants) don't hold up — those constants aren't in the tree.

### Builds

`esp32`, `esp32s3`, `esp32c3` all compile clean.

### Hardware testing

Not merging until someone confirms on real hardware — ideally @Garkus98 on the S3 and C3 from #2309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LgPhX92D1RCmZgYQwNAFN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rate-limited requests from generating an additional response.
  * Added automatic device recovery when available memory remains critically low.
  * Reset low-memory monitoring when memory levels recover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->