### PR TITLE
fix(mqtt): stop dropping bytes mid-packet on short TCP writes (#2218)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -61,7 +61,7 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer@3.9.3
   https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.5
   https://github.com/ESPresense/NimBLE-Arduino.git#1.4.0
-  marvinroger/AsyncMqttClient@^0.9.0
+  https://github.com/ESPresense/async-mqtt-client.git#v0.9.2
   bblanchon/ArduinoJson@^6.21.5
   kitesurfer1404/WS2812FX@^1.4.2
 board_build.partitions = partitions_singleapp.csv
@@ -116,7 +116,7 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer@3.9.3
   https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.4
   h2zero/NimBLE-Arduino@^2.3.7
-  marvinroger/AsyncMqttClient@^0.9.0
+  https://github.com/ESPresense/async-mqtt-client.git#v0.9.2
   bblanchon/ArduinoJson@^6.21.5
   kitesurfer1404/WS2812FX@^1.4.2
 build_flags =
@@ -150,7 +150,7 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer@3.9.3
   https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.5
   h2zero/NimBLE-Arduino@^2.3.7
-  marvinroger/AsyncMqttClient@^0.9.0
+  https://github.com/ESPresense/async-mqtt-client.git#v0.9.2
   bblanchon/ArduinoJson@^6.21.5
   kitesurfer1404/WS2812FX@^1.4.2
 build_flags =


### PR DESCRIPTION
Fixes #2218.

## Root cause

`AsyncMqttClient::_handleQueue()` advances its `_sent` cursor by the count it *requested* from `AsyncClient::add()` and explicitly discards the count `add()` actually took:

```cpp
size_t willSend = std::min(_head->size() - _sent, _client.space());
size_t realSent = _client.add(..., willSend, ASYNC_WRITE_FLAG_COPY);
_sent += willSend;   // requested
(void)realSent;      // actual — discarded
```

AsyncTCP 3.4.9's `add()` can return less than requested in two ways:

- **0**, when `tcp_write()` fails with `ERR_MEM` — reachable with `tcp_sndbuf() > 0` whenever the pbuf pool is exhausted or `TCP_SND_QUEUELEN` is full;
- **a short count**, when sndbuf shrank between the `space()` read and the write.

Either way `_sent` advances past bytes that never left. They're never retransmitted, so the broker consumes the head of the next queued packet as the tail of the current one and its stream parser reads fixed headers at the wrong offset.

**One defect, all three reported symptoms:**

| Broker log | Actually is |
|---|---|
| `disconnected due to malformed packet` | parser reading a header at the wrong offset |
| `Invalid PUBLISH (QoS=0 and DUP=1)` | a misread flags nibble — not the client setting DUP |
| `has exceeded timeout` | the corrupt publish was the last packet the broker recognised; keepalive then runs out |

This is also why raising `max_keepalive` never helped and why good RSSI was a red herring — the socket isn't idle and WiFi isn't dropping.

## Fix

[ESPresense/async-mqtt-client@v0.9.2](https://github.com/ESPresense/async-mqtt-client/releases/tag/v0.9.2) — advance by `realSent`, and `break` when nothing went out so the queue retries from `_onAck()`/`_onPoll()` (both are registered in the ctor, so this can't stall). `ASYNC_WRITE_FLAG_COPY` is set, so the unsent tail is still in the packet's buffer and resuming is safe. The SSL path keeps `willSend` because `add()` reports encrypted length there.

v0.9.2 also logs the short-write path. `log_e` not `log_w` deliberately: standard flavors build at `CORE_DEBUG_LEVEL=1`, which strips anything below error, so a warning would report nothing on the firmware people actually run.

## Evidence

**Reported by @reffr** with a 26-node fleet analysis in https://github.com/ESPresense/ESPresense/issues/2218#issuecomment-5098845519 — including the detail that the spliced content is our own `espresense/rooms/*/+/set` subscribe filter from `main.cpp:314`, appearing in truncated payloads.

**Independently found and fixed identically** in [abratchik/async-mqtt-client@182eff98](https://github.com/abratchik/async-mqtt-client/commit/182eff98) (2026-04-12), ~3.5 months earlier, with no issue or PR connecting the two. I surveyed all 256 forks of `marvinroger/async-mqtt-client`; 16 have commits past upstream and that is the only one carrying this fix.

**Host-side harness** modelling the cursor logic against a mock `add()` that fails the way AsyncTCP's does, 500 randomized trials:

```
shipped code corrupt: 220
patched code corrupt: 0
PASS: shipped code loses bytes, patch preserves the stream and drains
```

The harness asserts the queue fully drains, which is what rules out `break`-on-`ERR_MEM` deadlocking.

Structurally corroborating: `espMqttClient`, the maintained rewrite, does `_bytesSent += written` — it advances by the actual write return, the invariant AsyncMqttClient violates.

## Note on prior attempts

#2219, #2256 and #2262 all proposed adding `mqttClient.loop()` for this issue. AsyncMqttClient has no `loop()` — it's callback-driven off AsyncTCP. Those were guesses at the symptom.

## Testing status

Builds clean locally on esp32 / esp32c3 / esp32s3 (one per changed `lib_deps` block).

**Not yet hardware-confirmed.** @reffr — could you flash this on your fleet when you get a chance? The alpha link will be posted below once CI finishes. Your baseline gives unusually crisp pass criteria:

- no `Invalid PUBLISH (QoS=0 and DUP=1)` for `espresense-*`
- no `disconnected due to malformed packet`
- no reaps clustered at ~1.5x keepalive
- no truncated payloads carrying `espresense/rooms/*/+/set` in the tail
- session lifetimes no longer pinned at ~188 s

The new `short write N/M` log lines are the useful part — they tell us the defective path fired and the connection survived it, rather than leaving us to infer from absence of symptoms. If you still have them, the raw broker logs and analysis scripts you offered would help for the before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbxF5tPKtubPws29RBwpwn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT connectivity and compatibility across ESP32, ESP32-S3, and ESP32-C6 devices.
  * Updated the MQTT communication layer to improve connection stability and behavior across supported hardware.
  * Enhanced compatibility with current MQTT services and device configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->