### PR TITLE
ci(hil): pull firmware-tester:1 fresh each run

### DIFF
--- a/.woodpecker/hil-verbose.yml
+++ b/.woodpecker/hil-verbose.yml
@@ -7,6 +7,7 @@ when:
 steps:
   - name: test-esp32-verbose
     image: ghcr.io/espresense/firmware-tester:1
+    pull: true
     privileged: true
     depends_on: []
     volumes:
@@ -39,6 +40,7 @@ steps:
 
   - name: test-esp32c3-verbose
     image: ghcr.io/espresense/firmware-tester:1
+    pull: true
     privileged: true
     depends_on: []
     volumes:
@@ -71,6 +73,7 @@ steps:
 
   - name: test-esp32c6-verbose
     image: ghcr.io/espresense/firmware-tester:1
+    pull: true
     privileged: true
     depends_on: []
     failure: ignore
@@ -104,6 +107,7 @@ steps:
 
   - name: test-esp32s3-verbose
     image: ghcr.io/espresense/firmware-tester:1
+    pull: true
     privileged: true
     depends_on: []
     volumes:

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -9,6 +9,7 @@ when:
 steps:
   - name: test-esp32
     image: ghcr.io/espresense/firmware-tester:1
+    pull: true
     privileged: true
     depends_on: []
     volumes:
@@ -47,6 +48,7 @@ steps:
 
   - name: test-esp32c3
     image: ghcr.io/espresense/firmware-tester:1
+    pull: true
     privileged: true
     depends_on: []
     volumes:
@@ -85,6 +87,7 @@ steps:
 
   - name: test-esp32c6
     image: ghcr.io/espresense/firmware-tester:1
+    pull: true
     privileged: true
     depends_on: []
     volumes:
@@ -123,6 +126,7 @@ steps:
 
   - name: test-esp32s3
     image: ghcr.io/espresense/firmware-tester:1
+    pull: true
     privileged: true
     depends_on: []
     volumes:


### PR DESCRIPTION
The HIL steps pin the floating `ghcr.io/espresense/firmware-tester:1` tag but have no pull policy, so the Woodpecker runner keeps a cached image and never picks up updates pushed to that tag.

Concretely: firmware-tester **v1.0.5** (the `/json` concurrency check from firmware-tester#7) has been the `:1` image since 2026-07-24, but no pipeline since shows the check running — the runner is still on the pre-v1.0.5 image. Verified by grepping the last several pipeline logs: zero `/json check` lines, not even the SKIPPED path.

`pull: true` forces a fresh pull each run, so moving the `:1` tag actually takes effect — which is the entire point of pinning a major tag instead of a digest. Applied to every step in both `hil.yml` and `hil-verbose.yml`.

### Self-validating

This PR's own HIL run is the test: if the fix works, the log will now show `[hil] /json check passed` (or a loud SKIPPED if the runner can't route to the device). If it's still silent, the cause is something other than the pull policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LgPhX92D1RCmZgYQwNAFN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hardware-in-the-loop test runs to always pull the latest firmware tester image.
  * Applied this behavior across ESP32, ESP32-C3, ESP32-C6, and ESP32-S3 test configurations, including verbose manual tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->