### PR TITLE
ci(hil): pin HIL to the docker/Linux agent

### DIFF
--- a/.woodpecker/hil-verbose.yml
+++ b/.woodpecker/hil-verbose.yml
@@ -4,6 +4,11 @@
 when:
   - event: manual
 
+# Pin to the docker/Linux agent with the ESP32 hardware (see hil.yml).
+labels:
+  backend: docker
+  platform: linux/amd64
+
 steps:
   - name: test-esp32-verbose
     image: ghcr.io/espresense/firmware-tester:1

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -6,6 +6,13 @@ when:
   - event: cron
     branch: main
 
+# Pin to the docker/Linux agent with the ESP32 hardware. Without this the scheduler
+# can hand these steps (image:, privileged, /dev/esp32 mounts) to a local-backend
+# Windows agent, where they fail instantly with no useful log.
+labels:
+  backend: docker
+  platform: linux/amd64
+
 steps:
   - name: test-esp32
     image: ghcr.io/espresense/firmware-tester:1


### PR DESCRIPTION
### Problem

A Windows machine joined the Woodpecker agent pool:

| Agent | Platform | Backend |
|---|---|---|
| `28068aa3a8f1` | linux/amd64 | **docker** |
| `WINDOWS-D638UOG` | windows/amd64 | **local** |

The HIL steps need the docker backend — `image:`, `privileged: true`, `/dev/esp32*` device mounts — but had **no agent filter**, so Woodpecker's scheduler intermittently dispatched them to the Windows/local agent. There `image:` is ignored, there's no docker, no `/dev/esp32`, no `bash`/`flock` — so the step dies instantly with an empty log. That's why #2428's PR runs (pipelines 975/976) failed while an earlier push run happened to land on the Linux agent and ran fine.

### Fix

Add a workflow-level agent filter to both `hil.yml` and `hil-verbose.yml`:

```yaml
labels:
  backend: docker
  platform: linux/amd64
```

Only the docker/Linux host (which has the ESP32s attached) will run HIL now. `crow lint` passes on both files.

### Note

This makes routing correct regardless of what else joins the pool. If the Windows agent isn't meant to be in this server at all, that's a separate infra cleanup (agent-side), but the pipeline shouldn't depend on the pool's composition either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LgPhX92D1RCmZgYQwNAFN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hardware-in-the-loop pipeline execution settings to target Docker on Linux AMD64.
  * Preserved existing manual trigger behavior and pipeline steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->