### PR TITLE
hil: /json/tele heap endpoint + BLE flood during device tests

### DIFF
--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -48,6 +48,12 @@ steps:
             DURATION_SECS=28800
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+          # Ask the bench BLE flood (ble-flood.service on the host) for load, and stop
+          # asking however this step exits. Each step owns its own request file so one
+          # finishing early does not cut the flood out from under the others.
+          mkdir -p /lock/bleflood.d
+          touch /lock/bleflood.d/$FIRMWARE_ENV
+          trap "rm -f /lock/bleflood.d/$FIRMWARE_ENV" EXIT
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
@@ -87,6 +93,12 @@ steps:
             DURATION_SECS=28800
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+          # Ask the bench BLE flood (ble-flood.service on the host) for load, and stop
+          # asking however this step exits. Each step owns its own request file so one
+          # finishing early does not cut the flood out from under the others.
+          mkdir -p /lock/bleflood.d
+          touch /lock/bleflood.d/$FIRMWARE_ENV
+          trap "rm -f /lock/bleflood.d/$FIRMWARE_ENV" EXIT
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
@@ -126,6 +138,12 @@ steps:
             DURATION_SECS=28800
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+          # Ask the bench BLE flood (ble-flood.service on the host) for load, and stop
+          # asking however this step exits. Each step owns its own request file so one
+          # finishing early does not cut the flood out from under the others.
+          mkdir -p /lock/bleflood.d
+          touch /lock/bleflood.d/$FIRMWARE_ENV
+          trap "rm -f /lock/bleflood.d/$FIRMWARE_ENV" EXIT
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
@@ -165,6 +183,12 @@ steps:
             DURATION_SECS=28800
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+          # Ask the bench BLE flood (ble-flood.service on the host) for load, and stop
+          # asking however this step exits. Each step owns its own request file so one
+          # finishing early does not cut the flood out from under the others.
+          mkdir -p /lock/bleflood.d
+          touch /lock/bleflood.d/$FIRMWARE_ENV
+          trap "rm -f /lock/bleflood.d/$FIRMWARE_ENV" EXIT
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS

--- a/platformio.ini
+++ b/platformio.ini
@@ -376,3 +376,12 @@ build_flags =
   -D FIRMWARE='"macchina-a0"'
   -D SENSORS
   ${esp32.build_flags}
+
+; Host-side unit tests for logic that needs no hardware. Not in default_envs, so ordinary
+; firmware builds are untouched: pio test -e native
+[env:native]
+platform = native
+test_framework = unity
+lib_compat_mode = off
+lib_deps = bblanchon/ArduinoJson@^6.21.5
+build_flags = -std=gnu++17 -Wall -Wextra

--- a/src/HttpWebServer.cpp
+++ b/src/HttpWebServer.cpp
@@ -218,8 +218,6 @@ void Init(AsyncWebServer *server) {
 
     server->on("/restart", HTTP_POST, onRestart);
     server->on("/reboot", HTTP_POST, onRestart);
-    // reaches serveJson), and the first registered match wins — so registering this after
-    // it would silently route /json/tele into the 12KB path this exists to avoid.
     server->on("/json/tele", HTTP_GET, serveTele);
     server->on("/json", HTTP_GET, serveJson);
 

--- a/src/HttpWebServer.cpp
+++ b/src/HttpWebServer.cpp
@@ -218,7 +218,6 @@ void Init(AsyncWebServer *server) {
 
     server->on("/restart", HTTP_POST, onRestart);
     server->on("/reboot", HTTP_POST, onRestart);
-    // Before "/json": that handler matches path prefixes too (which is how /json/devices
     // reaches serveJson), and the first registered match wins — so registering this after
     // it would silently route /json/tele into the 12KB path this exists to avoid.
     server->on("/json/tele", HTTP_GET, serveTele);

--- a/src/HttpWebServer.cpp
+++ b/src/HttpWebServer.cpp
@@ -20,6 +20,31 @@ void serializeInfo(JsonObject &root) {
 #endif
 }
 
+// The three numbers telemetry already publishes over MQTT, on their own endpoint so a heap
+// complaint can be diagnosed with curl and no broker: freeHeap falling while fingerprints
+// holds steady is a leak, maxHeap falling while freeHeap holds is fragmentation, both
+// moving with the device count is churn. Working that out took months of graph-swapping
+// on #2309.
+//
+// Deliberately allocation-free, and deliberately not routed through serveJson. That path
+// refuses with 429 when it cannot afford a 12KB document — so hanging these numbers off it
+// would hide them precisely when the node is in the trouble they describe. A fixed stack
+// buffer answers at any heap level. It also keeps the cost off /json, which the UI polls:
+// no fingerprintMutex acquisition (contending the scan task) and no second walk of the
+// free-block list on every poll.
+void serveTele(AsyncWebServerRequest *request) {
+    char buf[224];
+    // Size(false): a GET reports what is there, it does not expire fingerprints as a side
+    // effect of being observed.
+    snprintf(buf, sizeof(buf),
+             "{\"room\":\"%s\",\"freeHeap\":%u,\"maxHeap\":%u,\"fingerprints\":%u}",
+             room.c_str(),
+             static_cast<unsigned>(ESP.getFreeHeap()),
+             static_cast<unsigned>(ESP.getMaxAllocHeap()),
+             static_cast<unsigned>(BleFingerprintCollection::Size(false)));
+    request->send(200, "application/json", buf);
+}
+
 void serializeState(JsonObject &root) {
     JsonObject node = root.createNestedObject("state");
     node["enrolling"] = enrolling;
@@ -193,6 +218,10 @@ void Init(AsyncWebServer *server) {
 
     server->on("/restart", HTTP_POST, onRestart);
     server->on("/reboot", HTTP_POST, onRestart);
+    // Before "/json": that handler matches path prefixes too (which is how /json/devices
+    // reaches serveJson), and the first registered match wins — so registering this after
+    // it would silently route /json/tele into the 12KB path this exists to avoid.
+    server->on("/json/tele", HTTP_GET, serveTele);
     server->on("/json", HTTP_GET, serveJson);
 
     server->on("/json/configs", HTTP_DELETE, [](AsyncWebServerRequest *request) {

--- a/src/HttpWebServer.cpp
+++ b/src/HttpWebServer.cpp
@@ -3,6 +3,7 @@
 #include "ArduinoJson.h"
 #include "AsyncJson.h"
 #include "Enrollment.h"
+#include "TeleJson.h"
 #include "defaults.h"
 #include "globals.h"
 #include "mqtt.h"
@@ -33,15 +34,20 @@ void serializeInfo(JsonObject &root) {
 // no fingerprintMutex acquisition (contending the scan task) and no second walk of the
 // free-block list on every poll.
 void serveTele(AsyncWebServerRequest *request) {
-    char buf[224];
+    char buf[256];
     // Size(false): a GET reports what is there, it does not expire fingerprints as a side
     // effect of being observed.
-    snprintf(buf, sizeof(buf),
-             "{\"room\":\"%s\",\"freeHeap\":%u,\"maxHeap\":%u,\"fingerprints\":%u}",
-             room.c_str(),
-             static_cast<unsigned>(ESP.getFreeHeap()),
-             static_cast<unsigned>(ESP.getMaxAllocHeap()),
-             static_cast<unsigned>(BleFingerprintCollection::Size(false)));
+    size_t const len = buildTeleJson(buf, sizeof(buf), room.c_str(),
+                                     ESP.getFreeHeap(),
+                                     ESP.getMaxAllocHeap(),
+                                     BleFingerprintCollection::Size(false));
+    if (len == 0) {
+        // Only reachable via an absurdly long room. Refusing beats the alternative: a
+        // truncated body under a 200 is indistinguishable from a corrupt response, and
+        // this endpoint is what people reach for when they already distrust the node.
+        request->send(500, "application/json", F("{\"error\":\"telemetry did not fit\"}"));
+        return;
+    }
     request->send(200, "application/json", buf);
 }
 

--- a/src/TeleJson.h
+++ b/src/TeleJson.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <ArduinoJson.h>
+
+#include <cstddef>
+#include <cstdint>
+
+// Body builder for /json/tele, kept apart from HttpWebServer.cpp so it can be tested
+// without the web server. See serveTele() for why this endpoint avoids the heap.
+//
+// Returns bytes written, or 0 if the document did not fit — callers must refuse rather
+// than send a partial body. A 200 carrying half a JSON object is the "success that lies"
+// failure mode this endpoint exists to help diagnose, so it must not be one.
+//
+// `room` is user-set free text (main.cpp: HeadlessWiFiSettings.string("room", ...)), so a
+// quote, backslash or control character in it would break a hand-formatted body.
+// ArduinoJson escapes at serialization time; that is the whole reason not to snprintf this.
+inline size_t buildTeleJson(char *out, size_t size, const char *room,
+                            uint32_t freeHeap, uint32_t maxHeap, uint32_t fingerprints) {
+    if (out == nullptr || size == 0) return 0;
+
+    // Stack, not DynamicJsonDocument: this endpoint has to answer when the heap is too
+    // short for /json to reply at all. A const char* is stored by pointer rather than
+    // copied, so a long room costs no capacity here — it shows up in the length check
+    // below instead, which is what catches it.
+    StaticJsonDocument<JSON_OBJECT_SIZE(4)> doc;
+    doc["room"] = room;
+    doc["freeHeap"] = freeHeap;
+    doc["maxHeap"] = maxHeap;
+    doc["fingerprints"] = fingerprints;
+
+    if (doc.overflowed()) return 0;
+    if (measureJson(doc) >= size) return 0;  // >= : leave room for the NUL
+    return serializeJson(doc, out, size);
+}

--- a/test/test_native_tele/test_tele_json.cpp
+++ b/test/test_native_tele/test_tele_json.cpp
@@ -1,0 +1,117 @@
+// /json/tele body builder: escaping and the refuse-rather-than-truncate rule.
+//
+// The room name is user-set free text, and the body is parsed by machines (Home Assistant,
+// the companion, the HIL monitor). A quote in the room name used to produce a malformed
+// body served as 200, and an over-long one used to produce a truncated body served as 200.
+#include <cstring>
+#include <string>
+
+#include <unity.h>
+
+#include "../../src/TeleJson.h"
+
+namespace {
+
+std::string build(const char* room, size_t size = 256) {
+    std::string out(size, '\0');
+    size_t const len = buildTeleJson(&out[0], size, room, 84710, 28236, 29);
+    if (len == 0) return "";
+    out.resize(len);
+    return out;
+}
+
+void expect_fields(const std::string& body) {
+    TEST_ASSERT_TRUE(body.find("\"freeHeap\":84710") != std::string::npos);
+    TEST_ASSERT_TRUE(body.find("\"maxHeap\":28236") != std::string::npos);
+    TEST_ASSERT_TRUE(body.find("\"fingerprints\":29") != std::string::npos);
+}
+
+void test_plain_room(void) {
+    std::string const body = build("Dining");
+    TEST_ASSERT_EQUAL_STRING(
+        "{\"room\":\"Dining\",\"freeHeap\":84710,\"maxHeap\":28236,\"fingerprints\":29}",
+        body.c_str());
+}
+
+void test_quote_is_escaped(void) {
+    std::string const body = build("Da\"ta");
+    TEST_ASSERT_TRUE(body.find("\"room\":\"Da\\\"ta\"") != std::string::npos);
+    expect_fields(body);
+}
+
+void test_backslash_is_escaped(void) {
+    std::string const body = build("back\\slash");
+    TEST_ASSERT_TRUE(body.find("\"room\":\"back\\\\slash\"") != std::string::npos);
+    expect_fields(body);
+}
+
+void test_control_characters_are_escaped(void) {
+    std::string const body = build("a\nb\tc");
+    // Raw control bytes in a JSON string are invalid; they must come out escaped.
+    TEST_ASSERT_TRUE(body.find('\n') == std::string::npos);
+    TEST_ASSERT_TRUE(body.find('\t') == std::string::npos);
+    TEST_ASSERT_TRUE(body.find("\\n") != std::string::npos);
+    TEST_ASSERT_TRUE(body.find("\\t") != std::string::npos);
+    expect_fields(body);
+}
+
+void test_injection_attempt_stays_inside_the_string(void) {
+    // A room that tries to close the string and add its own key must not manage it: the
+    // body has to keep exactly the four keys.
+    std::string const body = build("x\",\"freeHeap\":\"0");
+    TEST_ASSERT_TRUE(body.find("\\\"") != std::string::npos);
+    TEST_ASSERT_TRUE(body.find("\"freeHeap\":84710") != std::string::npos);
+    size_t count = 0;
+    for (size_t at = body.find("\"freeHeap\""); at != std::string::npos;
+         at = body.find("\"freeHeap\"", at + 1)) {
+        count++;
+    }
+    TEST_ASSERT_EQUAL_UINT(1, count);  // the injected one is inside the room string
+}
+
+void test_oversized_room_is_refused_not_truncated(void) {
+    std::string const huge(4096, 'x');
+    std::string out(256, '\0');
+    TEST_ASSERT_EQUAL_UINT(0, buildTeleJson(&out[0], out.size(), huge.c_str(), 1, 2, 3));
+}
+
+void test_escaping_growth_is_accounted_for(void) {
+    // Escaping can double the length, so a room that fits raw may not fit encoded. The
+    // check has to measure the *encoded* size, which is the bug this guards.
+    std::string const quotes(200, '"');
+    std::string out(256, '\0');
+    TEST_ASSERT_EQUAL_UINT(0, buildTeleJson(&out[0], out.size(), quotes.c_str(), 1, 2, 3));
+}
+
+void test_exact_fit_boundary(void) {
+    std::string const body = build("Dining");
+    size_t const needed = body.size();
+    std::string out(needed + 1, '\0');
+    // One byte short must refuse rather than write a truncated object.
+    TEST_ASSERT_EQUAL_UINT(0, buildTeleJson(&out[0], needed, "Dining", 84710, 28236, 29));
+    // Exactly enough (plus the NUL) must succeed.
+    TEST_ASSERT_EQUAL_UINT(needed,
+                           buildTeleJson(&out[0], needed + 1, "Dining", 84710, 28236, 29));
+}
+
+void test_degenerate_buffers(void) {
+    char buf[8];
+    TEST_ASSERT_EQUAL_UINT(0, buildTeleJson(nullptr, sizeof(buf), "Dining", 1, 2, 3));
+    TEST_ASSERT_EQUAL_UINT(0, buildTeleJson(buf, 0, "Dining", 1, 2, 3));
+}
+
+}  // namespace
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_plain_room);
+    RUN_TEST(test_quote_is_escaped);
+    RUN_TEST(test_backslash_is_escaped);
+    RUN_TEST(test_control_characters_are_escaped);
+    RUN_TEST(test_injection_attempt_stays_inside_the_string);
+    RUN_TEST(test_oversized_room_is_refused_not_truncated);
+    RUN_TEST(test_escaping_growth_is_accounted_for);
+    RUN_TEST(test_exact_fit_boundary);
+    RUN_TEST(test_degenerate_buffers);
+    return UNITY_END();
+}


### PR DESCRIPTION
Two changes that let the HIL bench reproduce **and** detect the slow heap decline in #2309. Companion: ESPresense/firmware-tester#9.

### 1. `/json/tele` — `freeHeap`, `maxHeap`, `fingerprints`

These three numbers already go out over MQTT telemetry, but nothing served them over HTTP. Diagnosing a heap complaint meant broker access and correlating graphs by hand, which is a large part of why #2309 stayed open for months. With them on an endpoint the three failure modes separate with `curl` alone:

- `freeHeap` falling while `fingerprints` holds steady → a leak
- `maxHeap` falling while `freeHeap` holds → fragmentation
- both moving with the device count → fingerprint churn

**Its own endpoint, not `serializeInfo`.** Two reasons, and the first is the important one:

- **Availability.** `serveJson` refuses with 429 when it cannot afford a 12KB document. Heap numbers hung off `/json` would therefore vanish *exactly* when the node is in the trouble they describe — and the HIL sampler would lose its tail samples as a node degraded, comparing a healthier window and under-reporting the decline. `serveTele` writes a fixed stack buffer and answers at any heap level.
- **Cost.** `/json` is polled by the UI, and `serializeInfo` runs on every `/json` *and* `/json/devices` request. Putting these there would add a `fingerprintMutex` acquisition (contending the BLE scan task) plus a second walk of the free-block list to every poll.

Registered *before* `/json`, because that handler also matches path prefixes — which is how `/json/devices` reaches `serveJson` — and the first registered match wins. `Size(false)` so a GET reports what is there rather than expiring fingerprints as a side effect of being observed.

Costs **170 bytes of flash** on esp32c3; RAM unchanged.

### 2. HIL steps request the BLE flood

Each step drops a request file into `/var/lock/woodpecker/bleflood.d/` on entry and removes it via an `EXIT` trap, so the bench flood advertises unique identities for the duration of the test and goes quiet afterwards. The lock directory is already bind-mounted, so no new mounts and no host access from CI. A directory of per-step requests rather than one flag: the four steps finish at different times and the first one out must not cut the flood out from under the others.

Each flood advert is a distinct MAC *and* a distinct name — ESPresense ranks `ID_TYPE_NAME` (35) above `ID_TYPE_RAND_STATIC_MAC` (5), so a constant name collapses the whole flood onto one logical id. Found on live hardware, not in review.

### Testing

- `esp32c3` builds clean; flash +170 B, RAM unchanged.
- Flood verified on the bench with a passed-through Intel adapter: 4777 unique addresses at 39.8/s, picked up and fingerprinted by a live node in range.
- `/json/tele` itself has **not** been exercised on hardware yet — the bench nodes are erased and the new monitor ships in the firmware-tester image.

Per policy this does not merge until a real node has served `/json/tele` and a HIL run has reported heap samples. Suggested path: merge firmware-tester#9 (does not disturb the running HIL — `hil.yml` pins `firmware-tester:1`, which only moves on a `v1.*` tag), pin this branch to `firmware-tester:latest` for one validation run, then revert the pin and tag a release once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WcHJEDXvf1KhT6BfpoVNG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a telemetry endpoint reporting room information, available memory, maximum allocatable memory, and non-cleaning fingerprint counts.
* **Tests**
  * Improved hardware testing setup and cleanup for BLE-flood testing across supported ESP32 variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->