### PR TITLE
ci(hil): run the BLE flood as a detached pipeline step

### DIFF
--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -14,7 +14,6 @@ labels:
   platform: linux/amd64
 
 steps:
-  # BLE advertisement flood```
   - name: ble-flood
     image: ghcr.io/espresense/ble-loadgen:1
     pull: true

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -14,13 +14,7 @@ labels:
   platform: linux/amd64
 
 steps:
-  # BLE advertisement flood, one fresh random address ~40x/sec, so every node burns
-  # fingerprint slots and the #2309 heap decline shows up in a HIL window. Detached: it
-  # starts with the run and the runner kills it at the end. network_mode host because raw
-  # HCI (HCI_CHANNEL_USER) only works in the host netns — a bridge-net container can't even
-  # open an AF_BLUETOOTH socket. Needs the USB adapter passed through to the bench and BlueZ
-  # absent (see the ble-loadgen README). No commands: the image entrypoint is
-  # `python3 ble_flood.py` and its CMD supplies --index/--rate.
+  # BLE advertisement flood```
   - name: ble-flood
     image: ghcr.io/espresense/ble-loadgen:1
     pull: true

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -19,16 +19,15 @@ steps:
   # starts with the run and the runner kills it at the end. network_mode host because raw
   # HCI (HCI_CHANNEL_USER) only works in the host netns — a bridge-net container can't even
   # open an AF_BLUETOOTH socket. Needs the USB adapter passed through to the bench and BlueZ
-  # absent (see firmware-tester bench/README.md).
+  # absent (see the ble-loadgen README). No commands: the image entrypoint is
+  # `python3 ble_flood.py` and its CMD supplies --index/--rate.
   - name: ble-flood
-    image: ghcr.io/espresense/firmware-tester:1
+    image: ghcr.io/espresense/ble-loadgen:1
     pull: true
     detach: true
     privileged: true
     network_mode: host
     depends_on: []
-    commands:
-      - python3 /scripts/ble_flood.py --index 0 --rate 40
 
   - name: test-esp32
     image: ghcr.io/espresense/firmware-tester:1

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -14,6 +14,22 @@ labels:
   platform: linux/amd64
 
 steps:
+  # BLE advertisement flood, one fresh random address ~40x/sec, so every node burns
+  # fingerprint slots and the #2309 heap decline shows up in a HIL window. Detached: it
+  # starts with the run and the runner kills it at the end. network_mode host because raw
+  # HCI (HCI_CHANNEL_USER) only works in the host netns — a bridge-net container can't even
+  # open an AF_BLUETOOTH socket. Needs the USB adapter passed through to the bench and BlueZ
+  # absent (see firmware-tester bench/README.md).
+  - name: ble-flood
+    image: ghcr.io/espresense/firmware-tester:1
+    pull: true
+    detach: true
+    privileged: true
+    network_mode: host
+    depends_on: []
+    commands:
+      - python3 /scripts/ble_flood.py --index 0 --rate 40
+
   - name: test-esp32
     image: ghcr.io/espresense/firmware-tester:1
     pull: true
@@ -48,12 +64,6 @@ steps:
             DURATION_SECS=28800
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          # Ask the bench BLE flood (ble-flood.service on the host) for load, and stop
-          # asking however this step exits. Each step owns its own request file so one
-          # finishing early does not cut the flood out from under the others.
-          mkdir -p /lock/bleflood.d
-          touch /lock/bleflood.d/$FIRMWARE_ENV
-          trap "rm -f /lock/bleflood.d/$FIRMWARE_ENV" EXIT
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
@@ -93,12 +103,6 @@ steps:
             DURATION_SECS=28800
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          # Ask the bench BLE flood (ble-flood.service on the host) for load, and stop
-          # asking however this step exits. Each step owns its own request file so one
-          # finishing early does not cut the flood out from under the others.
-          mkdir -p /lock/bleflood.d
-          touch /lock/bleflood.d/$FIRMWARE_ENV
-          trap "rm -f /lock/bleflood.d/$FIRMWARE_ENV" EXIT
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
@@ -138,12 +142,6 @@ steps:
             DURATION_SECS=28800
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          # Ask the bench BLE flood (ble-flood.service on the host) for load, and stop
-          # asking however this step exits. Each step owns its own request file so one
-          # finishing early does not cut the flood out from under the others.
-          mkdir -p /lock/bleflood.d
-          touch /lock/bleflood.d/$FIRMWARE_ENV
-          trap "rm -f /lock/bleflood.d/$FIRMWARE_ENV" EXIT
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
@@ -183,12 +181,6 @@ steps:
             DURATION_SECS=28800
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          # Ask the bench BLE flood (ble-flood.service on the host) for load, and stop
-          # asking however this step exits. Each step owns its own request file so one
-          # finishing early does not cut the flood out from under the others.
-          mkdir -p /lock/bleflood.d
-          touch /lock/bleflood.d/$FIRMWARE_ENV
-          trap "rm -f /lock/bleflood.d/$FIRMWARE_ENV" EXIT
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS


### PR DESCRIPTION
Moves the BLE flood into the HIL pipeline as a detached step, sourced from the new **[ESPresense/ble-loadgen](https://github.com/ESPresense/ble-loadgen)** image.

### Why

The flood was a systemd service on the bench host (`firmware-tester bench/ble-flood.service`) gated by a request directory these steps touched. **It was never installed** — so every heap-trend run so far measured ambient house BLE, not the flood. Making it a pipeline step means "is it running" is a property of the run, not of host state that can silently drift.

### What

- **New detached `ble-flood` step** on `ghcr.io/espresense/ble-loadgen:1`. `detach: true` → starts with the run, runner kills it at the end. No `commands:` — the image entrypoint is `python3 ble_flood.py`, CMD supplies `--index 0 --rate 40`.
- **Removed the flag-dir plumbing** (`mkdir /lock/bleflood.d`, `touch`, `trap`) from all four device steps — the detached step's lifetime is the run, so there's nothing to gate.
- `/var/lock/woodpecker:/lock` mount stays (still used for the per-device `flock`).

### The one constraint

Raw HCI (`HCI_CHANNEL_USER`) only works in the **host network namespace** — verified on the bench, a bridge-net container gets `EAFNOSUPPORT` opening the `AF_BLUETOOTH` socket. So the flood step sets `network_mode: host`. It's confined to this one step; the device-test steps are untouched.

### Companion

- ESPresense/ble-loadgen — new repo/image (v1.0.1, `:1` published).
- ESPresense/firmware-tester#10 — removes the flood from firmware-tester (it moved out).

### Validates

First run after this lands: the `ble-flood` step logs `[flood] hci0 claimed, rotating at 40.0/s`, and the device steps' heap samples show `fingerprints` climbing toward the 200 cap (vs. the ~44 ambient in pipeline 1000) — the flood finally reaching the nodes, which is the point of measuring #2309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LgPhX92D1RCmZgYQwNAFN