### PR TITLE
fix: don't abort in pub() when heap can't afford the MQTT packet

### DIFF
--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -7,6 +7,15 @@
 
 bool pub(const char *topic, uint8_t qos, bool retain, const char *payload, size_t length, bool dup, uint16_t message_id)
 {
+    // AsyncMqttClient builds the outgoing packet in a std::vector<uint8_t>. Under memory
+    // pressure that reserve() fails, and because we build with -fno-exceptions a failed
+    // std::vector allocation calls abort() rather than throwing — a hard crash instead of a
+    // dropped message. The vector needs one contiguous block roughly the size of the packet
+    // (topic + payload + MQTT framing), so gate on the largest free block, not total heap.
+    // ponytail: 256B covers topic + framing; a skipped telemetry publish beats a reboot.
+    if (ESP.getMaxAllocHeap() < length + 256)
+        return false;
+
     for (int i = 0; i < 10; i++)
     {
         if (mqttClient.publish(topic, qos, retain, payload, length, dup, message_id))


### PR DESCRIPTION
First crash the BLE-flood HIL repro (ble-loadgen) found. Under the flood's memory pressure, dual-core nodes hard-abort. Decoding the esp32 backtrace with addr2line:

```
loop() → reportLoop() → pub() → AsyncMqttClient PublishOutPacket ctor
       → std::vector<uint8_t>::reserve() → __throw_bad_alloc → abort()
```

### Root cause

AsyncMqttClient builds each outgoing packet in a `std::vector<uint8_t>`. Under low heap that `reserve()` fails — and because the firmware is built **`-fno-exceptions`**, a failed `std::vector`/`std::string` allocation calls **`abort()`** instead of throwing a catchable `bad_alloc`. So a moment of memory pressure turns a droppable telemetry message into a crash + reboot.

This is a whole *class* of bug (any stdlib allocation under OOM aborts), which is why the flood is a good repro tool — it surfaces these sites fast.

### Fix

Guard `pub()`: if the largest free block can't hold the packet (payload + topic + MQTT framing), skip the publish and return false instead of letting the vector abort. `getMaxAllocHeap()` (largest contiguous block), not `getFreeHeap()`, because the vector needs one contiguous allocation — same reasoning as the `serveJson` low-heap guard (#2428).

```cpp
if (ESP.getMaxAllocHeap() < length + 256)
    return false;
```

### Scope

This fixes the **MQTT publish** abort site (the esp32 crash). The S3 aborted on core 0 with a different backtrace — likely a second OOM site (JSON serialization) — which the flood will surface next and can get the same treatment. One repro, one fix at a time.

Builds: `esp32`, `esp32s3` clean.

Not the #2309 *slow leak* per se — the 40/s flood is a firehose that exposes OOM-*crash* robustness bugs rather than the gradual decline. Both matter; this is the first.

Refs #2309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LgPhX92D1RCmZgYQwNAFN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT publication reliability under low-memory conditions.
  * Publications now fail safely when insufficient contiguous memory is available, preventing allocation-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->