### PR TITLE
fix(ble): stop holding fingerprintMutex across onDel logging

### DIFF
--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -20,25 +20,24 @@ struct FingerprintSlot {
 std::vector<FingerprintSlot> fingerprints;
 size_t activeFingerprints = 0;
 
-// Fingerprints detached from their slot, owned here until onDel runs.
-// Notification happens outside fingerprintMutex — onDel logs to serial/TCP and
-// blocks for milliseconds, which starved the other task's 100ms mutex wait.
-std::vector<BleFingerprint *> pendingNotify;
+// Fingerprints detached from their slot, owned here until FingerprintLock's
+// destructor notifies and frees them outside the mutex.
+std::vector<BleFingerprint *> dying;
 
 void removeSlot(size_t index, bool notify = true) {
     auto &slot = fingerprints[index];
     if (slot.fingerprint == nullptr || slot.refs != 0)
         return;
 
-    auto *dying = slot.fingerprint;
+    auto *doomed = slot.fingerprint;
     slot.fingerprint = nullptr;
     if (activeFingerprints > 0)
         --activeFingerprints;
 
     if (notify && onDel)
-        pendingNotify.push_back(dying);
+        dying.push_back(doomed);
     else
-        delete dying;
+        delete doomed;
 }
 
 size_t findEmptySlot() {
@@ -155,6 +154,34 @@ const TickType_t MAX_WAIT = pdMS_TO_TICKS(100);
 unsigned long lastCleanup = 0;
 SemaphoreHandle_t fingerprintMutex;
 SemaphoreHandle_t deviceConfigMutex;
+
+// Holds fingerprintMutex for the scope, then runs the deferred onDel callbacks
+// *after* releasing it. onDel logs to serial and TCP, which blocks for
+// milliseconds per line — doing that under the lock starved the other task's
+// MAX_WAIT acquire and dropped BLE advertisements.
+struct FingerprintLock {
+    const bool ok;
+
+    FingerprintLock() : ok(xSemaphoreTake(fingerprintMutex, MAX_WAIT) == pdTRUE) {}
+
+    ~FingerprintLock() {
+        if (!ok) return;
+
+        std::vector<BleFingerprint *> doomed;
+        doomed.swap(dying);  // hand off while we still hold the lock
+        xSemaphoreGive(fingerprintMutex);
+
+        for (auto *f : doomed) {
+            if (onDel) onDel(f);
+            delete f;
+        }
+    }
+
+    FingerprintLock(const FingerprintLock &) = delete;
+    FingerprintLock &operator=(const FingerprintLock &) = delete;
+
+    explicit operator bool() const { return ok; }
+};
 
 void Setup() {
     fingerprintMutex = xSemaphoreCreateMutex();
@@ -300,7 +327,8 @@ bool Config(String &id, String &json) {
         }
     }
 
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
+    FingerprintLock lock;
+    if (!lock) {
         log_e("Couldn't take fingerprintMutex in Config!");
         return false;
     }
@@ -318,7 +346,6 @@ bool Config(String &id, String &json) {
         } else
             fingerprint->fingerprintAddress();
     }
-    xSemaphoreGive(fingerprintMutex);
 
     return true;
 }
@@ -443,7 +470,7 @@ bool Command(String &command, String &pay) {
  *
  * Runs at most once every 5 seconds; each fingerprint whose time since last seen
  * exceeds `forgetMs` is detached from its slot and queued for `onDel` notification,
- * which the caller runs via notifyPending() once fingerprintMutex is released. If no
+ * which FingerprintLock runs once it releases fingerprintMutex. If no
  * fingerprints remain and the system uptime exceeds `ALLOW_BLE_CONTROLLER_RESTART_AFTER_SECS`,
  * the function logs a message and calls `ESP.restart()`.
  *
@@ -522,61 +549,31 @@ FingerprintLease getFingerprintInternal(BLEAdvertisedDevice *advertisedDevice) {
     return {created, slotIndex};
 }
 
-/**
- * @brief Run the onDel callback for fingerprints retired since the last drain.
- *
- * Must be called with fingerprintMutex NOT held: onDel writes to serial and TCP,
- * which blocks long enough to time out the other task's MAX_WAIT acquire.
- */
-void notifyPending() {
-    for (;;) {
-        if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) return;
-        if (pendingNotify.empty()) {
-            xSemaphoreGive(fingerprintMutex);
-            return;
-        }
-        auto *dying = pendingNotify.back();
-        pendingNotify.pop_back();
-        xSemaphoreGive(fingerprintMutex);
-
-        if (onDel) onDel(dying);
-        delete dying;
-    }
-}
-
 #ifdef NIMBLE_V2
 FingerprintLease GetFingerprint(const NimBLEAdvertisedDevice *advertisedDevice) {
 #else
 FingerprintLease GetFingerprint(BLEAdvertisedDevice *advertisedDevice) {
 #endif
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
+    FingerprintLock lock;
+    if (!lock) {
         log_e("Couldn't take semaphore!");
         return {};
     }
-    auto f = getFingerprintInternal(advertisedDevice);
-    xSemaphoreGive(fingerprintMutex);
-    notifyPending();
-    return f;
+    return getFingerprintInternal(advertisedDevice);
 }
 
 FingerprintLease AcquireNext(size_t &cursor, bool cleanup) {
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
+    FingerprintLock lock;
+    if (!lock) {
         log_e("Couldn't take fingerprintMutex!");
         return {};
     }
     if (cleanup) CleanupOldFingerprints();
 
-    while (cursor < fingerprints.size()) {
-        auto lease = acquireSlot(cursor++);
-        if (lease) {
-            xSemaphoreGive(fingerprintMutex);
-            notifyPending();
+    while (cursor < fingerprints.size())
+        if (auto lease = acquireSlot(cursor++))
             return lease;
-        }
-    }
 
-    xSemaphoreGive(fingerprintMutex);
-    notifyPending();
     return {};
 }
 
@@ -584,7 +581,8 @@ void Release(FingerprintLease &lease) {
     if (!lease)
         return;
 
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
+    FingerprintLock lock;
+    if (!lock) {
         log_e("Couldn't take fingerprintMutex!");
         // Leak the lease rather than touch shared state without the mutex —
         // the slot's refs stays elevated so the fingerprint isn't freed
@@ -598,20 +596,17 @@ void Release(FingerprintLease &lease) {
             --slot.refs;
     }
 
-    xSemaphoreGive(fingerprintMutex);
     lease = {};
 }
 
 size_t Size(bool cleanup) {
-    if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) {
+    FingerprintLock lock;
+    if (!lock) {
         log_e("Couldn't take fingerprintMutex!");
         return 0;
     }
     if (cleanup) CleanupOldFingerprints();
-    auto count = activeFingerprints;
-    xSemaphoreGive(fingerprintMutex);
-    notifyPending();
-    return count;
+    return activeFingerprints;
 }
 
 bool FindDeviceConfig(const String &id, DeviceConfig &config) {

--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -15,33 +15,30 @@ namespace {
 struct FingerprintSlot {
     BleFingerprint *fingerprint = nullptr;
     uint16_t refs = 0;
-    bool pendingDelete = false;
 };
 
 std::vector<FingerprintSlot> fingerprints;
 size_t activeFingerprints = 0;
 
-void finalizeSlot(FingerprintSlot &slot) {
-    if (!slot.pendingDelete || slot.refs != 0 || slot.fingerprint == nullptr)
-        return;
-
-    delete slot.fingerprint;
-    slot.fingerprint = nullptr;
-    slot.pendingDelete = false;
-}
+// Fingerprints detached from their slot, owned here until onDel runs.
+// Notification happens outside fingerprintMutex — onDel logs to serial/TCP and
+// blocks for milliseconds, which starved the other task's 100ms mutex wait.
+std::vector<BleFingerprint *> pendingNotify;
 
 void removeSlot(size_t index, bool notify = true) {
     auto &slot = fingerprints[index];
-    if (slot.fingerprint == nullptr || slot.pendingDelete)
+    if (slot.fingerprint == nullptr || slot.refs != 0)
         return;
 
-    if (notify && onDel)
-        onDel(slot.fingerprint);
-
-    slot.pendingDelete = true;
+    auto *dying = slot.fingerprint;
+    slot.fingerprint = nullptr;
     if (activeFingerprints > 0)
         --activeFingerprints;
-    finalizeSlot(slot);
+
+    if (notify && onDel)
+        pendingNotify.push_back(dying);
+    else
+        delete dying;
 }
 
 size_t findEmptySlot() {
@@ -57,7 +54,7 @@ size_t findEvictionSlot() {
 
     for (size_t i = 0; i < fingerprints.size(); ++i) {
         auto &slot = fingerprints[i];
-        if (slot.fingerprint == nullptr || slot.pendingDelete || slot.refs != 0)
+        if (slot.fingerprint == nullptr || slot.refs != 0)
             continue;
 
         auto age = slot.fingerprint->getMsSinceLastSeen();
@@ -80,7 +77,7 @@ size_t findAvailableSlot() {
         return eviction;
 
     removeSlot(eviction);
-    return fingerprints[eviction].fingerprint == nullptr ? eviction : static_cast<size_t>(-1);
+    return eviction;
 }
 
 void configureSlots(size_t capacity) {
@@ -96,7 +93,7 @@ void configureSlots(size_t capacity) {
 
 FingerprintLease acquireSlot(size_t index) {
     auto &slot = fingerprints[index];
-    if (slot.fingerprint == nullptr || slot.pendingDelete)
+    if (slot.fingerprint == nullptr)
         return {};
 
     ++slot.refs;
@@ -106,7 +103,7 @@ FingerprintLease acquireSlot(size_t index) {
 FingerprintLease findByAddress(const NimBLEAddress &mac) {
     for (size_t i = fingerprints.size(); i-- > 0;) {
         auto &slot = fingerprints[i];
-        if (slot.fingerprint != nullptr && !slot.pendingDelete && slot.fingerprint->getAddress() == mac)
+        if (slot.fingerprint != nullptr && slot.fingerprint->getAddress() == mac)
             return acquireSlot(i);
     }
     return {};
@@ -114,7 +111,7 @@ FingerprintLease findByAddress(const NimBLEAddress &mac) {
 
 BleFingerprint *findById(const String &id) {
     for (auto &slot : fingerprints)
-        if (slot.fingerprint != nullptr && !slot.pendingDelete && slot.fingerprint->getId() == id)
+        if (slot.fingerprint != nullptr && slot.fingerprint->getId() == id)
             return slot.fingerprint;
     return nullptr;
 }
@@ -153,7 +150,7 @@ TCallbackFingerprint onCountAdd = nullptr;
 TCallbackFingerprint onCountDel = nullptr;
 
 // Private
-const TickType_t MAX_WAIT = portTICK_PERIOD_MS * 100;
+const TickType_t MAX_WAIT = pdMS_TO_TICKS(100);
 
 unsigned long lastCleanup = 0;
 SemaphoreHandle_t fingerprintMutex;
@@ -308,7 +305,7 @@ bool Config(String &id, String &json) {
         return false;
     }
     for (auto &slot : fingerprints) {
-        if (slot.fingerprint == nullptr || slot.pendingDelete)
+        if (slot.fingerprint == nullptr)
             continue;
 
         auto *fingerprint = slot.fingerprint;
@@ -444,11 +441,13 @@ bool Command(String &command, String &pay) {
 /**
  * @brief Removes stale Bluetooth fingerprints and performs end-of-life actions.
  *
- * Runs at most once every 5 seconds; for each fingerprint whose time since last seen
- * exceeds `forgetMs` this function invokes the `onDel` callback (if set), deletes
- * the fingerprint object, and removes it from the internal collection. If no
+ * Runs at most once every 5 seconds; each fingerprint whose time since last seen
+ * exceeds `forgetMs` is detached from its slot and queued for `onDel` notification,
+ * which the caller runs via notifyPending() once fingerprintMutex is released. If no
  * fingerprints remain and the system uptime exceeds `ALLOW_BLE_CONTROLLER_RESTART_AFTER_SECS`,
  * the function logs a message and calls `ESP.restart()`.
+ *
+ * Must be called with fingerprintMutex held.
  */
 void CleanupOldFingerprints() {
     auto now = millis();
@@ -457,15 +456,15 @@ void CleanupOldFingerprints() {
     bool any = false;
     for (size_t i = 0; i < fingerprints.size(); ++i) {
         auto &slot = fingerprints[i];
-        if (slot.fingerprint == nullptr || slot.pendingDelete)
+        if (slot.fingerprint == nullptr)
             continue;
 
-        auto age = slot.fingerprint->getMsSinceLastSeen();
-        if (age > forgetMs) {
-            removeSlot(i);
-        } else {
+        // A leased fingerprint still counts as present; removeSlot() won't touch it
+        // and it gets reaped on a later pass once the reader releases.
+        if (slot.refs != 0 || slot.fingerprint->getMsSinceLastSeen() <= forgetMs)
             any = true;
-        }
+        else
+            removeSlot(i);
     }
     if (!any) {
         auto uptime = (unsigned long)(esp_timer_get_time() / 1000000ULL);
@@ -519,9 +518,30 @@ FingerprintLease getFingerprintInternal(BLEAdvertisedDevice *advertisedDevice) {
     auto &slot = fingerprints[slotIndex];
     slot.fingerprint = created;
     slot.refs = 1;
-    slot.pendingDelete = false;
     ++activeFingerprints;
     return {created, slotIndex};
+}
+
+/**
+ * @brief Run the onDel callback for fingerprints retired since the last drain.
+ *
+ * Must be called with fingerprintMutex NOT held: onDel writes to serial and TCP,
+ * which blocks long enough to time out the other task's MAX_WAIT acquire.
+ */
+void notifyPending() {
+    for (;;) {
+        if (xSemaphoreTake(fingerprintMutex, MAX_WAIT) != pdTRUE) return;
+        if (pendingNotify.empty()) {
+            xSemaphoreGive(fingerprintMutex);
+            return;
+        }
+        auto *dying = pendingNotify.back();
+        pendingNotify.pop_back();
+        xSemaphoreGive(fingerprintMutex);
+
+        if (onDel) onDel(dying);
+        delete dying;
+    }
 }
 
 #ifdef NIMBLE_V2
@@ -535,6 +555,7 @@ FingerprintLease GetFingerprint(BLEAdvertisedDevice *advertisedDevice) {
     }
     auto f = getFingerprintInternal(advertisedDevice);
     xSemaphoreGive(fingerprintMutex);
+    notifyPending();
     return f;
 }
 
@@ -549,11 +570,13 @@ FingerprintLease AcquireNext(size_t &cursor, bool cleanup) {
         auto lease = acquireSlot(cursor++);
         if (lease) {
             xSemaphoreGive(fingerprintMutex);
+            notifyPending();
             return lease;
         }
     }
 
     xSemaphoreGive(fingerprintMutex);
+    notifyPending();
     return {};
 }
 
@@ -571,10 +594,8 @@ void Release(FingerprintLease &lease) {
 
     if (lease.slot < fingerprints.size()) {
         auto &slot = fingerprints[lease.slot];
-        if (slot.fingerprint == lease.fingerprint && slot.refs > 0) {
+        if (slot.fingerprint == lease.fingerprint && slot.refs > 0)
             --slot.refs;
-            finalizeSlot(slot);
-        }
     }
 
     xSemaphoreGive(fingerprintMutex);
@@ -589,6 +610,7 @@ size_t Size(bool cleanup) {
     if (cleanup) CleanupOldFingerprints();
     auto count = activeFingerprints;
     xSemaphoreGive(fingerprintMutex);
+    notifyPending();
     return count;
 }
 


### PR DESCRIPTION
## Problem

HIL pipeline 1000 (BLE flood, added in #2430) logs floods of:

```
[E][BleFingerprintCollection.cpp:533] GetFingerprint(): Couldn't take semaphore!
[E][BleFingerprintCollection.cpp:543] AcquireNext(): Couldn't take fingerprintMutex!
```

interleaved with hundreds of `1 Del | hil-xxxx` lines.

`removeSlot()` invoked the `onDel` callback **while `fingerprintMutex` was held**.
`onDel` lands in `GUI::Removed()` → `Log.printf()` → a blocking UART write
(~8ms/line at 115200) plus an AsyncTCP write.

That ran under the lock from two places:

- `CleanupOldFingerprints()` — reached from `Size(true)` (main `reportLoop`),
  `AcquireNext(cursor, true)` (`HttpWebServer::serializeDevices`), and
  `getFingerprintInternal()` (BLE scan callback task).
- `findAvailableSlot()` eviction — once the pool is full, *every* new advertisement
  evicts and logs a `Del` while holding the lock.

The flood advertises unique MACs, so the pool saturates and then mass-expires at
`forget_ms` (150s). One cleanup pass reaps hundreds of slots without releasing the
mutex, so the other task's 100ms `xSemaphoreTake` fails and the advert is dropped.

Nothing is corrupted, but adverts are silently dropped and `/json` returns short
device lists whenever the node is busy.

## Fix

- `removeSlot()` detaches the fingerprint, frees the slot immediately, and queues the
  pointer. `notifyPending()` runs `onDel` and deletes it **outside** the mutex; called
  after `xSemaphoreGive` in `GetFingerprint`, `AcquireNext` (both exits), and `Size`.
  The slot is reusable on the same call, so eviction is unaffected — only the `Del` log
  line is deferred, and it still precedes the matching `New`.
- `removeSlot()` / `CleanupOldFingerprints()` skip leased slots (`refs != 0`) and reap
  them on a later 5s pass instead. Leases are held only across a single
  `fill()` / `query()` / `reportDevice()`. This makes the two-phase
  `pendingDelete` / `finalizeSlot` teardown dead code, so it's removed.
- `MAX_WAIT` was `portTICK_PERIOD_MS * 100` — ms→ticks inverted. Now `pdMS_TO_TICKS(100)`.
  Same value at ESP32's 1kHz tick, so no behavior change.

One file, +57/−35.

## Testing

- `pio run -e esp32 -e esp32c3 -e esp32s3` — all SUCCESS
- `pio test -e native` — 22/22 pass

No new native test: the collection pulls in NimBLE and won't build natively without
heavy stubbing. The HIL flood test is the real check — pass criteria on the pipeline log:

- zero `Couldn't take semaphore!` / `Couldn't take fingerprintMutex!`
- `Del` lines still appear for flooded devices (notification not lost)
- no `Dropping BLE fingerprint; max_fingerprints=... is exhausted` spam
- no `Bluetooth controller seems stuck, restarting`
- `/json/tele` `fingerprints` holds at the pool cap during the flood, drains ~150s after

**Not merged until someone confirms on real hardware.**

## Not doing here

- Serial write serialization. Two tasks writing `Log.printf` + `esp_log` concurrently
  produce the interleaved lines visible in the pipeline output. Cosmetic, separate issue.
- Bounding removals per cleanup pass. With the log write off the lock, a 200-slot sweep
  is microseconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5hen3XWN6uBRSz3YpMBgc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fingerprint deletion and cleanup reliability.
  * Ensured leased fingerprints remain available until they are released.
  * Preserved recently seen fingerprints while safely removing expired, unused entries.
  * Improved the reliability of fingerprint retrieval, iteration, release, and size operations.
  * Prevented deletion notifications from interrupting active fingerprint operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->