### PR TITLE
diag: heap-by-capability logging under the flood (#2309, not for merge)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -674,6 +674,21 @@ void setup() {
  */
 void loop() {
     reportLoop();
+    // #2309 diagnostic: which heap capability actually depletes under the BLE flood. The
+    // failing allocations are INTERNAL / INTERNAL+DMA (PSRAM can't satisfy them). Both
+    // sizes falling together = genuine exhaustion; free staying high while the largest
+    // block collapses = fragmentation. Logged every second so the ~11s-to-crash window
+    // is captured at resolution the 5s slow-loop can't give.
+    static unsigned long lastHeapLog = 0;
+    if (millis() - lastHeapLog > 1000) {
+        lastHeapLog = millis();
+        Log.printf("HEAPCAP int_free=%u int_max=%u dma_free=%u dma_max=%u dflt_free=%u\r\n",
+                   (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+                   (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL),
+                   (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA),
+                   (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA),
+                   (unsigned)heap_caps_get_free_size(MALLOC_CAP_DEFAULT));
+    }
     static unsigned long lastSlowLoop = 0;
     if (millis() - lastSlowLoop > 5000) {
         lastSlowLoop = millis();


### PR DESCRIPTION
Instrumentation, not a fix. After three wrong root-cause guesses, this logs INTERNAL/DMA free + largest-block every second so the BLE flood shows exactly what depletes and whether it's exhaustion or fragmentation. Read the `HEAPCAP` lines in the device steps, then design the real fix from data.

Refs #2309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added once-per-second diagnostics displaying free memory and largest available block sizes across key heap types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->