### PR TITLE
ci(hil): give each HIL step its own PlatformIO build dir

### DIFF
--- a/.woodpecker/hil-verbose.yml
+++ b/.woodpecker/hil-verbose.yml
@@ -34,11 +34,13 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32/platforms
     commands:
       - |
+        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
+      - |
         flock -w 3600 /lock/esp32-verbose.lock bash -c '
           set -e
           DURATION_SECS=${MANUAL_DURATION_SECS:-1800}
-          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -67,11 +69,13 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32c3/platforms
     commands:
       - |
+        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
+      - |
         flock -w 3600 /lock/esp32c3-verbose.lock bash -c '
           set -e
           DURATION_SECS=${MANUAL_DURATION_SECS:-1800}
-          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -101,11 +105,13 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32c6/platforms
     commands:
       - |
+        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
+      - |
         flock -w 3600 /lock/esp32c6-verbose.lock bash -c '
           set -e
           DURATION_SECS=${MANUAL_DURATION_SECS:-1800}
-          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -134,11 +140,13 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32s3/platforms
     commands:
       - |
+        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
+      - |
         flock -w 3600 /lock/esp32s3-verbose.lock bash -c '
           set -e
           DURATION_SECS=${MANUAL_DURATION_SECS:-1800}
-          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '

--- a/.woodpecker/hil-verbose.yml
+++ b/.woodpecker/hil-verbose.yml
@@ -36,12 +36,10 @@ steps:
       - |
         export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
-      - |
         flock -w 3600 /lock/esp32-verbose.lock bash -c '
           set -e
           DURATION_SECS=${MANUAL_DURATION_SECS:-1800}
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -72,12 +70,10 @@ steps:
       - |
         export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
-      - |
         flock -w 3600 /lock/esp32c3-verbose.lock bash -c '
           set -e
           DURATION_SECS=${MANUAL_DURATION_SECS:-1800}
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -109,12 +105,10 @@ steps:
       - |
         export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
-      - |
         flock -w 3600 /lock/esp32c6-verbose.lock bash -c '
           set -e
           DURATION_SECS=${MANUAL_DURATION_SECS:-1800}
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -145,12 +139,10 @@ steps:
       - |
         export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
-      - |
         flock -w 3600 /lock/esp32s3-verbose.lock bash -c '
           set -e
           DURATION_SECS=${MANUAL_DURATION_SECS:-1800}
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '

--- a/.woodpecker/hil-verbose.yml
+++ b/.woodpecker/hil-verbose.yml
@@ -36,7 +36,7 @@ steps:
       - |
         export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/esp32-verbose.lock bash -c '
+        flock -w 3600 /lock/esp32.lock bash -c '
           set -e
           DURATION_SECS=${MANUAL_DURATION_SECS:-1800}
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
@@ -70,7 +70,7 @@ steps:
       - |
         export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/esp32c3-verbose.lock bash -c '
+        flock -w 3600 /lock/esp32c3.lock bash -c '
           set -e
           DURATION_SECS=${MANUAL_DURATION_SECS:-1800}
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
@@ -105,7 +105,7 @@ steps:
       - |
         export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/esp32c6-verbose.lock bash -c '
+        flock -w 3600 /lock/esp32c6.lock bash -c '
           set -e
           DURATION_SECS=${MANUAL_DURATION_SECS:-1800}
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
@@ -139,7 +139,7 @@ steps:
       - |
         export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/esp32s3-verbose.lock bash -c '
+        flock -w 3600 /lock/esp32s3.lock bash -c '
           set -e
           DURATION_SECS=${MANUAL_DURATION_SECS:-1800}
           PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload

--- a/.woodpecker/hil-verbose.yml
+++ b/.woodpecker/hil-verbose.yml
@@ -34,6 +34,7 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32/platforms
     commands:
       - |
+        export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
         flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
       - |
@@ -69,6 +70,7 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32c3/platforms
     commands:
       - |
+        export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
         flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
       - |
@@ -105,6 +107,7 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32c6/platforms
     commands:
       - |
+        export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
         flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
       - |
@@ -140,6 +143,7 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32s3/platforms
     commands:
       - |
+        export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
         flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
       - |

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -46,6 +46,9 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32/platforms
     commands:
       - |
+        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
+      - |
         flock -w 3600 /lock/esp32.lock bash -c '
           set -e
           if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
@@ -55,12 +58,7 @@ steps:
           else
             DURATION_SECS=28800
           fi
-          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          # Serialize build+upload across all pipelines/chips (one at a time) so concurrent
-          # builds cannot clobber the shared cache/workspace (ld: reopening firmware.elf,
-          # missing .d files). The long monitor below stays under the per-device lock, so
-          # device runs still parallelize.
-          flock -w 3600 /lock/build.lock env PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -89,6 +87,9 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32c3/platforms
     commands:
       - |
+        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
+      - |
         flock -w 3600 /lock/esp32c3.lock bash -c '
           set -e
           if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
@@ -98,12 +99,7 @@ steps:
           else
             DURATION_SECS=28800
           fi
-          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          # Serialize build+upload across all pipelines/chips (one at a time) so concurrent
-          # builds cannot clobber the shared cache/workspace (ld: reopening firmware.elf,
-          # missing .d files). The long monitor below stays under the per-device lock, so
-          # device runs still parallelize.
-          flock -w 3600 /lock/build.lock env PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -132,6 +128,9 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32c6/platforms
     commands:
       - |
+        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
+      - |
         flock -w 3600 /lock/esp32c6.lock bash -c '
           set -e
           if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
@@ -141,12 +140,7 @@ steps:
           else
             DURATION_SECS=28800
           fi
-          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          # Serialize build+upload across all pipelines/chips (one at a time) so concurrent
-          # builds cannot clobber the shared cache/workspace (ld: reopening firmware.elf,
-          # missing .d files). The long monitor below stays under the per-device lock, so
-          # device runs still parallelize.
-          flock -w 3600 /lock/build.lock env PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -175,6 +169,9 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32s3/platforms
     commands:
       - |
+        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
+      - |
         flock -w 3600 /lock/esp32s3.lock bash -c '
           set -e
           if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
@@ -184,12 +181,7 @@ steps:
           else
             DURATION_SECS=28800
           fi
-          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          # Serialize build+upload across all pipelines/chips (one at a time) so concurrent
-          # builds cannot clobber the shared cache/workspace (ld: reopening firmware.elf,
-          # missing .d files). The long monitor below stays under the per-device lock, so
-          # device runs still parallelize.
-          flock -w 3600 /lock/build.lock env PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -46,6 +46,7 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32/platforms
     commands:
       - |
+        export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
         flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
       - |
@@ -87,6 +88,7 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32c3/platforms
     commands:
       - |
+        export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
         flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
       - |
@@ -128,6 +130,7 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32c6/platforms
     commands:
       - |
+        export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
         flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
       - |
@@ -169,6 +172,7 @@ steps:
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32s3/platforms
     commands:
       - |
+        export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
         flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
       - |

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -48,8 +48,6 @@ steps:
       - |
         export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
-      - |
         flock -w 3600 /lock/esp32.lock bash -c '
           set -e
           if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
@@ -59,7 +57,7 @@ steps:
           else
             DURATION_SECS=28800
           fi
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -90,8 +88,6 @@ steps:
       - |
         export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
-      - |
         flock -w 3600 /lock/esp32c3.lock bash -c '
           set -e
           if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
@@ -101,7 +97,7 @@ steps:
           else
             DURATION_SECS=28800
           fi
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -132,8 +128,6 @@ steps:
       - |
         export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
-      - |
         flock -w 3600 /lock/esp32c6.lock bash -c '
           set -e
           if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
@@ -143,7 +137,7 @@ steps:
           else
             DURATION_SECS=28800
           fi
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -174,8 +168,6 @@ steps:
       - |
         export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
         git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/build.lock pio run -e $FIRMWARE_ENV
-      - |
         flock -w 3600 /lock/esp32s3.lock bash -c '
           set -e
           if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
@@ -185,7 +177,7 @@ steps:
           else
             DURATION_SECS=28800
           fi
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t nobuild -t erase -t upload
+          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -56,7 +56,11 @@ steps:
             DURATION_SECS=28800
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          # Serialize build+upload across all pipelines/chips (one at a time) so concurrent
+          # builds cannot clobber the shared cache/workspace (ld: reopening firmware.elf,
+          # missing .d files). The long monitor below stays under the per-device lock, so
+          # device runs still parallelize.
+          flock -w 3600 /lock/build.lock env PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -95,7 +99,11 @@ steps:
             DURATION_SECS=28800
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          # Serialize build+upload across all pipelines/chips (one at a time) so concurrent
+          # builds cannot clobber the shared cache/workspace (ld: reopening firmware.elf,
+          # missing .d files). The long monitor below stays under the per-device lock, so
+          # device runs still parallelize.
+          flock -w 3600 /lock/build.lock env PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -134,7 +142,11 @@ steps:
             DURATION_SECS=28800
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          # Serialize build+upload across all pipelines/chips (one at a time) so concurrent
+          # builds cannot clobber the shared cache/workspace (ld: reopening firmware.elf,
+          # missing .d files). The long monitor below stays under the per-device lock, so
+          # device runs still parallelize.
+          flock -w 3600 /lock/build.lock env PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '
@@ -173,7 +185,11 @@ steps:
             DURATION_SECS=28800
           fi
           git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+          # Serialize build+upload across all pipelines/chips (one at a time) so concurrent
+          # builds cannot clobber the shared cache/workspace (ld: reopening firmware.elf,
+          # missing .d files). The long monitor below stays under the per-device lock, so
+          # device runs still parallelize.
+          flock -w 3600 /lock/build.lock env PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
           python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
           python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
         '


### PR DESCRIPTION
Concurrent HIL steps clobber each other's build output: `ld: reopening firmware.elf: No such file`, `Button.cpp.d: No such file`.

Original diagnosis (concurrent *pipelines* fighting over the cache) was wrong. It's intra-pipeline: all four steps share one workspace, so they share `.pio/build`. Each step sets a different `PLATFORMIO_CORE_DIR`, so every `pio run` sees a changed project checksum and wipes the **whole** tree — including the other chips' output, mid-build. Logs from pipeline 1023 show it's mutual: `test-esp32` deleting `.pio/build/esp32c3/...`, `test-esp32c6` deleting `.pio/build/esp32/src/Enrollment.cpp.o`.

Fix: `PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"` per step. No step touches another's tree. No build lock needed — serializing builds would not have helped, since each step still deleted the others' output.

`git config` moves out of the device flock (it never needed it). Same change in `hil-verbose.yml`. `crow lint` passes.