### PR TITLE
DIAG (do not merge): #2309 S3 heap-corruption probes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -42,6 +42,7 @@ build_flags =
   ; flat floor. That fixes #2309: under the BLE flood the old unbounded queue grew until an
   ; allocation aborted; now publish() returns 0 once ~8KB is queued and reportLoop drops it.
   -D MQTT_MIN_FREE_MEMORY=12192
+  -D HEAP_DIAG ; diag/heap-corruption branch only — REVERT before merge (#2309 S3 overrun hunt)
   -D CONFIG_ASYNC_TCP_USE_WDT=0
   -D CONFIG_BT_NIMBLE_MSYS1_BLOCK_COUNT=20
   -D BLE_GATTC_UNRESPONSIVE_TIMEOUT_MS=2000

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,7 +43,7 @@ build_flags =
   ; more headroom than that, so they aborted first under load (#2309, every chip). 32KB keeps
   ; the backlog bounded in the zone the surviving nodes held (~30KB); tune on the flood.
   ; Binary-searching the minimum that survives the flood, doubling from the old 12192.
-  -D MQTT_MIN_FREE_MEMORY=24576
+  -D MQTT_MIN_FREE_MEMORY=49152
   -D CONFIG_ASYNC_TCP_USE_WDT=0
   -D CONFIG_BT_NIMBLE_MSYS1_BLOCK_COUNT=20
   -D BLE_GATTC_UNRESPONSIVE_TIMEOUT_MS=2000

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,13 +37,11 @@ build_flags =
   -D CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE=5632
   -D SCAN_TASK_STACK_SIZE=2562
   -D ARDUINO_LOOP_STACK_SIZE=6500
-  ; AsyncMqttClient refuses to enqueue a publish when the largest free block (getMaxAllocHeap)
-  ; is below this. At 12KB the outgoing backlog could grow until only 12KB contiguous remained
-  ; — but WiFi/BT coexistence, DMA TX buffers, TLS/AES and newlib locks run alongside and need
-  ; more headroom than that, so they aborted first under load (#2309, every chip). 32KB keeps
-  ; the backlog bounded in the zone the surviving nodes held (~30KB); tune on the flood.
-  ; Binary-searching the minimum that survives the flood, doubling from the old 12192.
-  -D MQTT_MIN_FREE_MEMORY=49152
+  ; async-mqtt-client v0.9.3 bounds the outgoing queue by bytes (MQTT_MAX_QUEUE_BYTES, 8192
+  ; default) and makes this a size-aware per-message headroom (free < message + this), not a
+  ; flat floor. That fixes #2309: under the BLE flood the old unbounded queue grew until an
+  ; allocation aborted; now publish() returns 0 once ~8KB is queued and reportLoop drops it.
+  -D MQTT_MIN_FREE_MEMORY=12192
   -D CONFIG_ASYNC_TCP_USE_WDT=0
   -D CONFIG_BT_NIMBLE_MSYS1_BLOCK_COUNT=20
   -D BLE_GATTC_UNRESPONSIVE_TIMEOUT_MS=2000

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,7 +37,13 @@ build_flags =
   -D CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE=5632
   -D SCAN_TASK_STACK_SIZE=2562
   -D ARDUINO_LOOP_STACK_SIZE=6500
-  -D MQTT_MIN_FREE_MEMORY=12192
+  ; AsyncMqttClient refuses to enqueue a publish when the largest free block (getMaxAllocHeap)
+  ; is below this. At 12KB the outgoing backlog could grow until only 12KB contiguous remained
+  ; — but WiFi/BT coexistence, DMA TX buffers, TLS/AES and newlib locks run alongside and need
+  ; more headroom than that, so they aborted first under load (#2309, every chip). 32KB keeps
+  ; the backlog bounded in the zone the surviving nodes held (~30KB); tune on the flood.
+  ; Binary-searching the minimum that survives the flood, doubling from the old 12192.
+  -D MQTT_MIN_FREE_MEMORY=24576
   -D CONFIG_ASYNC_TCP_USE_WDT=0
   -D CONFIG_BT_NIMBLE_MSYS1_BLOCK_COUNT=20
   -D BLE_GATTC_UNRESPONSIVE_TIMEOUT_MS=2000

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -682,11 +682,13 @@ void loop() {
         if (freeHeap > 40000) Updater::Loop();
 
         // ponytail: watchdog, not a leak fix. A heap-starved node limps forever (mqtt and
-        // telemetry both fail, nothing recovers), so reboot after 60s stuck below the
-        // threshold mqtt already refuses to publish under. Same escape hatch as the stuck
-        // BLE controller restart in BleFingerprintCollection::CleanupOldFingerprints().
+        // telemetry both fail, nothing recovers), so reboot after 60s of genuinely severe
+        // exhaustion. Decoupled from MQTT_MIN_FREE_MEMORY (the mqtt publish-backpressure
+        // threshold): that one is raised high enough to hold the node in a healthy band, so
+        // reusing it here would reboot a node that is actually fine and just shedding publishes.
+        static const uint32_t REBOOT_MIN_FREE_HEAP = 10000;
         static uint8_t lowHeapPasses = 0;
-        if (freeHeap < MQTT_MIN_FREE_MEMORY) {
+        if (freeHeap < REBOOT_MIN_FREE_HEAP) {
             if (++lowHeapPasses >= 12) {
                 Log.printf("Out of memory for 60s (%lu bytes free), restarting\r\n", static_cast<unsigned long>(freeHeap));
                 ESP.restart();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -682,13 +682,11 @@ void loop() {
         if (freeHeap > 40000) Updater::Loop();
 
         // ponytail: watchdog, not a leak fix. A heap-starved node limps forever (mqtt and
-        // telemetry both fail, nothing recovers), so reboot after 60s of genuinely severe
-        // exhaustion. Decoupled from MQTT_MIN_FREE_MEMORY (the mqtt publish-backpressure
-        // threshold): that one is raised high enough to hold the node in a healthy band, so
-        // reusing it here would reboot a node that is actually fine and just shedding publishes.
-        static const uint32_t REBOOT_MIN_FREE_HEAP = 10000;
+        // telemetry both fail, nothing recovers), so reboot after 60s stuck below the
+        // threshold mqtt already refuses to publish under. Same escape hatch as the stuck
+        // BLE controller restart in BleFingerprintCollection::CleanupOldFingerprints().
         static uint8_t lowHeapPasses = 0;
-        if (freeHeap < REBOOT_MIN_FREE_HEAP) {
+        if (freeHeap < MQTT_MIN_FREE_MEMORY) {
             if (++lowHeapPasses >= 12) {
                 Log.printf("Out of memory for 60s (%lu bytes free), restarting\r\n", static_cast<unsigned long>(freeHeap));
                 ESP.restart();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,11 +2,20 @@
 #include "main.h"
 
 #include "esp_heap_caps.h"
+#ifdef HEAP_DIAG
+#include "esp_debug_helpers.h"
+#endif
 
 
 void heapCapsAllocFailedHook(size_t requestedSize, uint32_t caps, const char *functionName)
 {
     ESP_EARLY_LOGE("heap", "%s failed to allocate %lu bytes with 0x%lX capabilities", functionName, static_cast<unsigned long>(requestedSize), static_cast<unsigned long>(caps));
+#ifdef HEAP_DIAG
+    // ponytail: diagnostic only (HEAP_DIAG). Print the caller stack for the first few failures
+    // so the flood shows WHO keeps asking for the recurring size that precedes the corruption.
+    static uint8_t traced = 0;
+    if (traced < 12) { traced++; esp_backtrace_print(12); }
+#endif
 }
 
 /**
@@ -674,6 +683,17 @@ void setup() {
  */
 void loop() {
     reportLoop();
+#ifdef HEAP_DIAG
+    // ponytail: diagnostic only (HEAP_DIAG). Scan the whole heap every second so the first
+    // corruption is caught within ~1s of the overrun, not later when some unrelated free()
+    // trips over the clobbered header and gives a useless backtrace.
+    static unsigned long lastIntegrity = 0;
+    if (millis() - lastIntegrity > 1000) {
+        lastIntegrity = millis();
+        if (!heap_caps_check_integrity_all(true))
+            Log.printf("HEAP CORRUPT detected at %lu ms, free=%lu\r\n", millis(), static_cast<unsigned long>(ESP.getFreeHeap()));
+    }
+#endif
     static unsigned long lastSlowLoop = 0;
     if (millis() - lastSlowLoop > 5000) {
         lastSlowLoop = millis();


### PR DESCRIPTION
**Not for merge.** Triggers the HIL flood with `-DHEAP_DIAG` to hunt the S3 heap overrun behind #2309.

The 1034 crash decoded to `multi_heap_free` poisoning assert (corrupted block header), unwinding to an innocent `free()` in `Switch::Loop()` — a victim frame, not the culprit. It reproduces the reporter's exact `2312 bytes / 0x1800` failure.

Two probes (behind `-DHEAP_DIAG`):
- `esp_backtrace_print` in `heapCapsAllocFailedHook` (first 12 fails) → who requests the recurring 2312-byte alloc.
- `heap_caps_check_integrity_all(true)` every 1s in `loop()` → catch the overrun within ~1s of the write, not at the later trip-over.

Revert branch after diagnosis. Refs #2309.