### PR TITLE
fix(#2309): serialize BLE fingerprint field access across cores

### DIFF
--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -188,6 +188,12 @@ void Setup() {
     deviceConfigMutex = xSemaphoreCreateMutex();
 }
 
+// Plain take/give of the same fingerprintMutex the lease system uses, exposed so cross-core
+// readers/writers can serialize a single fingerprint's field access (see header). Deliberately
+// no dying-drain like FingerprintLock — this guards short field snapshots, not slot lifecycle.
+bool LockFields() { return xSemaphoreTake(fingerprintMutex, MAX_WAIT) == pdTRUE; }
+void UnlockFields() { xSemaphoreGive(fingerprintMutex); }
+
 void Count(BleFingerprint *f, bool counting) {
     if (counting) {
         if (onCountAdd) onCountAdd(f);
@@ -212,8 +218,16 @@ void Seen(BLEAdvertisedDevice *advertisedDevice) {
 
     if (onSeen) onSeen(true);
     auto lease = GetFingerprint(advertisedDevice);
-    if (lease && lease.fingerprint->seen(advertisedDevice) && onAdd)
-        onAdd(lease.fingerprint);
+    bool added = false;
+    if (lease) {
+        // seen() writes the fingerprint's id/name/filter; hold the field lock so a reader on
+        // the other core (report loop, /json) can't tear a String mid-realloc. Not nested with
+        // GetFingerprint's lock (that one already released). Drop the advert if the lock is
+        // busy — cheaper than blocking the scan task past MAX_WAIT.
+        BleFingerprintCollection::FieldGuard g;
+        if (g) added = lease.fingerprint->seen(advertisedDevice);
+    }
+    if (added && onAdd) onAdd(lease.fingerprint);
     Release(lease);
     if (onSeen) onSeen(false);
 }

--- a/src/BleFingerprintCollection.h
+++ b/src/BleFingerprintCollection.h
@@ -51,6 +51,24 @@ FingerprintLease GetFingerprint(BLEAdvertisedDevice *advertisedDevice);
 void CleanupOldFingerprints();
 FingerprintLease AcquireNext(size_t &cursor, bool cleanup = true);
 void Release(FingerprintLease &lease);
+
+// Serializes a fingerprint's mutable String fields (id/name/discoveredIrk, written by the scan
+// task inside seen()) against readers on another core (report loop, /json serialize). A lease
+// only guards lifetime (refs), NOT concurrent field access — on a dual-core chip that let core 0
+// realloc a String while core 1 read its buffer pointer, a torn read that faulted (#2309).
+// Hold ONLY across the field read/write, never across MQTT/HTTP I/O: snapshot under the guard,
+// release, then do I/O. Never hold while calling AcquireNext/Release — fingerprintMutex is
+// non-recursive, so re-taking it on the same task self-deadlocks.
+bool LockFields();
+void UnlockFields();
+struct FieldGuard {
+    const bool ok;
+    FieldGuard() : ok(LockFields()) {}
+    ~FieldGuard() { if (ok) UnlockFields(); }
+    explicit operator bool() const { return ok; }
+    FieldGuard(const FieldGuard &) = delete;
+    FieldGuard &operator=(const FieldGuard &) = delete;
+};
 size_t Size(bool cleanup = true);
 bool FindDeviceConfig(const String &id, DeviceConfig &config);
 bool FindDeviceConfigByAlias(const String &alias, DeviceConfig &config);

--- a/src/HttpWebServer.cpp
+++ b/src/HttpWebServer.cpp
@@ -76,13 +76,20 @@ void serializeDevices(JsonObject &root, bool showAll) {
     size_t cursor = 0;
     while (auto lease = BleFingerprintCollection::AcquireNext(cursor)) {
         auto *fingerprint = lease.fingerprint;
-        bool visible = fingerprint->getVisible();
-        if (showAll || visible) {
-            JsonObject node = devices.createNestedObject();
-            if (fingerprint->fill(&node)) {
-                if (showAll && visible) node[F("vis")] = true;
-            } else
-                devices.remove(devices.size() - 1);
+        {
+            // fill() reads the fingerprint's id/name Strings while the scan task may be
+            // rewriting them on the other core (#2309). Hold the field lock across the read
+            // (ArduinoJson copies into node, so it's a snapshot), then release it BEFORE
+            // Release(lease) — the mutex is non-recursive and Release re-takes it.
+            BleFingerprintCollection::FieldGuard g;
+            bool visible = g && fingerprint->getVisible();
+            if (g && (showAll || visible)) {
+                JsonObject node = devices.createNestedObject();
+                if (fingerprint->fill(&node)) {
+                    if (showAll && visible) node[F("vis")] = true;
+                } else
+                    devices.remove(devices.size() - 1);
+            }
         }
         BleFingerprintCollection::Release(lease);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -467,18 +467,32 @@ void connectToMqtt() {
 
 bool reportBuffer(BleFingerprint *f) {
     if (!mqttClient.connected()) return false;
-    auto report = f->getReport();
-    String const topic = Sprintf(CHANNEL "/devices/%s/%s/%s", f->getId().c_str(), id.c_str(), report.getId().c_str());
-    return mqttClient.publish(topic.c_str(), 0, false, report.getPayload().c_str());
+    // Read f's fields into local snapshots under the field lock, then publish unlocked — the
+    // scan task mutates the same id/getReport() String on the other core (#2309 race).
+    String topic, payload;
+    {
+        BleFingerprintCollection::FieldGuard g;
+        if (!g) return false;
+        auto report = f->getReport();
+        topic = Sprintf(CHANNEL "/devices/%s/%s/%s", f->getId().c_str(), id.c_str(), report.getId().c_str());
+        payload = report.getPayload();
+    }
+    return mqttClient.publish(topic.c_str(), 0, false, payload.c_str());
 }
 
 bool reportDevice(BleFingerprint *f) {
     doc.clear();
     JsonObject obj = doc.to<JsonObject>();
-    if (!f->report(&obj))
-        return false;
-
-    String const devicesTopic = Sprintf(CHANNEL "/devices/%s/%s", f->getId().c_str(), id.c_str());
+    // report() reads f's id/name Strings into obj (ArduinoJson copies them, so doc is a
+    // self-contained snapshot) and updates f's report bookkeeping — all under the field lock so
+    // it can't race the scan task's seen() writes. pub() then serializes the snapshot unlocked.
+    String devicesTopic;
+    {
+        BleFingerprintCollection::FieldGuard g;
+        if (!g || !f->report(&obj))
+            return false;
+        devicesTopic = Sprintf(CHANNEL "/devices/%s/%s", f->getId().c_str(), id.c_str());
+    }
     if (pub(devicesTopic.c_str(), 0, false, doc))
         return true;
 


### PR DESCRIPTION
## Root cause (definitive)

The S3/esp32 dual-core crashes under load — `LoadProhibited` on a torn String pointer (`EXCVADDR 0x820151b4`) and the `multi_heap_free` poison assert, reproducing the reporter's exact `2312 bytes / 0x1800` failure — are a **data race**, not OOM:

A `FingerprintLease` guards a fingerprint's **lifetime** (refcount) but **not concurrent field access**. The scan task's `seen()` rewrites a fingerprint's `id`/`name` `String` on one core while the report loop and `/json` serialize read the same buffer on the other core → torn read of a `String` buffer mid-realloc → fault or heap-header corruption.

**Why it matches every symptom:** dual-core **S3 + esp32 crash**, single-core **c3/c6 pass** (they can't run writer and reader in parallel). Same NimBLE 2.3.7 on S3 and c6 → not the library. Reproduced deterministically by the BLE flood; addr2line + `esp_backtrace_print` in the alloc-fail hook both unwind to `onResult → Seen → fingerprint` (writer) vs `fill`/`report` (reader).

## Fix

A `FieldGuard` — plain take/give of the existing `fingerprintMutex` — held **only** across the field read/write, **never** across MQTT/HTTP I/O (snapshot under the guard, then release and do I/O, preserving the no-slow-work-under-lock property from the #2435 lifecycle rework already in main):

- `seen()` runs under the guard (writer).
- `reportDevice`/`reportBuffer` snapshot topic+payload under the guard, publish after.
- `serializeDevices` holds the guard across `fill()`, released **before** `Release(lease)` (mutex is non-recursive → self-deadlock otherwise).

Rebased onto current main (which already has #2435's lifetime fix for the c3/c6 corruption). All 4 chips build clean.

## Not yet covered (follow-ups)
- `query()` reads `id` / writes `discoveredIrk` during GATT I/O, but stops the scan first so it's largely exclusive with `seen()` — lower priority.
- The global `irks` vector is iterated on the scan core unlocked while `known_irks` config rebuilds it — latent, needs config churn to fire.

Per merge policy: needs a real S3 hardware pass (the flood) + explicit confirm before merge. Refs #2309.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fingerprint management during deletion and release, reducing stale data and callback timing issues.
  * Prevented inconsistent fingerprint information while device visibility and reports are being updated.
  * Improved reliability of device and report generation when data is changing concurrently.
* **Reliability**
  * Enhanced Bluetooth task coordination to reduce advertisement-processing conflicts on supported ESP32-S3 devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->