### PR TITLE
chore(ble): guard deprecated NimBLEService::start() behind NIMBLE_V2

### DIFF
--- a/src/Enrollment.cpp
+++ b/src/Enrollment.cpp
@@ -334,8 +334,11 @@ void Setup() {
     modelNum->setValue(std::string(room.c_str()));
     modelNum->setCallbacks(&chrCallbacks);
 
+#ifndef NIMBLE_V2
+    // NimBLE 2.x starts services with the server; start() is deprecated there.
     heartRate->start();
     deviceInfo->start();
+#endif
 
     uint32_t nodeId = (uint32_t)(ESP.getEfuseMac() >> 24);
     major = (nodeId & 0xFFFF0000) >> 16;


### PR DESCRIPTION
Building the NimBLE 2.x envs emits:

```
src/Enrollment.cpp:338:22: warning: 'bool NimBLEService::start()' is deprecated:
NimBLEService::start() has no effect. Services are started when the server is started.
```

In NimBLE 2.x services start with `pServer->start()`, so the two calls are no-ops.
The esp32/esp32c3 envs still build against NimBLE 1.4.0 where they're required, so
guarded with `#ifndef NIMBLE_V2` rather than deleted.

## Testing

- `pio run -e esp32s3` — SUCCESS, warning gone
- `pio run -e esp32` — SUCCESS, v1 path keeps the start calls
- Hardware enrollment test still needed before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DoHxpekhPja5zDMF3WfL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with NimBLE 2.x builds by preventing redundant startup operations.
  * Maintained existing startup behavior for other supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->