### PR TITLE
tune(ble): lower default max fingerprints on ESP32-S3 and classic ESP32

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -74,7 +74,7 @@
 #elif defined(ESP32C3) || defined(ESP32C6)
 #define DEFAULT_MAX_FINGERPRINTS 200
 #else
-#define DEFAULT_MAX_FINGERPRINTS 75
+#define DEFAULT_MAX_FINGERPRINTS 60
 #endif
 
 // RX_ADJ_RSSI Defaults

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -69,10 +69,12 @@
 #define DEFAULT_COUNT_EXIT 4.0f
 #define DEFAULT_COUNT_MS 10000
 #define DEFAULT_COUNT_IDS ""
-#if defined(ESP32S3) || defined(ESP32C3) || defined(ESP32C6)
+#if defined(ESP32S3)
+#define DEFAULT_MAX_FINGERPRINTS 150
+#elif defined(ESP32C3) || defined(ESP32C6)
 #define DEFAULT_MAX_FINGERPRINTS 200
 #else
-#define DEFAULT_MAX_FINGERPRINTS 100
+#define DEFAULT_MAX_FINGERPRINTS 75
 #endif
 
 // RX_ADJ_RSSI Defaults


### PR DESCRIPTION
Lowers the fingerprint pool default to leave more heap headroom under BLE flood:

| target | before | after |
|---|---|---|
| ESP32-S3 | 200 | **150** |
| ESP32-C3 / C6 | 200 | 200 (unchanged) |
| ESP32 (classic) | 100 | **60** |

S3 gets its own branch in `include/defaults.h` since it previously shared the
200 default with C3/C6.

This only changes the default. `max_fingerprints` remains user-configurable
(16–2048) and existing configs are untouched.

## Testing

- `pio run -e esp32s3` — SUCCESS
- `pio run -e esp32` — SUCCESS
- Hardware soak needed before merge to confirm the lower cap doesn't churn
  fingerprints in a busy environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5DoHxpekhPja5zDMF3WfL