### PR TITLE
fix(#2309): make Sprintf/Stdprintf OOM-safe (S3 Guru crash trigger)

### DIFF
--- a/lib/utils/string_utils.h
+++ b/lib/utils/string_utils.h
@@ -6,8 +6,12 @@
 
 #define CHIPID ((unsigned int)(ESP.getEfuseMac() >> 24))
 #define ESPMAC (Sprintf("%06x", CHIPID))
-#define Sprintf(f, ...) ({ char* s; asprintf(&s, f, __VA_ARGS__); const String r = s; free(s); r; })
-#define Stdprintf(f, ...) ({ char* s; asprintf(&s, f, __VA_ARGS__); const std::string r = s; free(s); r; })
+// asprintf mallocs *s and returns -1 on OOM leaving *s indeterminate. The old form read an
+// uninitialized s (String/std::string from a garbage pointer -> strlen/copy fault) and free()'d
+// it -> the #2309 S3 Guru (LoadProhibited / std::length_error) once the heap was exhausted.
+// Guard: only touch/free s when asprintf succeeded; otherwise yield an empty string.
+#define Sprintf(f, ...) ({ char* s = nullptr; String r; if (asprintf(&s, f, __VA_ARGS__) >= 0 && s) { r = s; free(s); } r; })
+#define Stdprintf(f, ...) ({ char* s = nullptr; std::string r; if (asprintf(&s, f, __VA_ARGS__) >= 0 && s) { r = s; free(s); } r; })
 
 std::string slugify(const std::string& text);
 String slugify(const String& text);


### PR DESCRIPTION
`asprintf()` mallocs `*s` and returns -1 on OOM, leaving `*s` **indeterminate**. Both macros read the uninitialized `s` into a `String`/`std::string` (`strlen`/copy on a garbage pointer) and `free()`'d it. Under the BLE flood, once the heap is exhausted this is the S3 crash: the decoded Guru is `std::length_error` / `basic_string::_M_replace_cold` (the `Stdprintf` path) and `LoadProhibited` in a ROM `strlen`/`memcpy` — and `getMac()` runs `Sprintf` on **every** advert via GUI logging.

Now `s` is only used/freed when `asprintf` succeeds; on failure the result is an empty string, so low heap degrades gracefully instead of Gury-crashing.

**Note:** this fixes the crash *trigger*. Under `-fno-exceptions`, exhaustion can still abort at other unchecked allocs, so it pairs with bounding the S3 fingerprint pool (proven: cap-60 survives the 3-min flood that crashes cap-200 — heap pressure, not a leak). Separate PR.

Per merge policy: needs a real S3 hardware pass. Refs #2309.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of formatting failures.
  * Prevented invalid or incomplete output when memory allocation fails.
  * Formatting utilities now return an empty result instead of potentially causing instability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->