### PR TITLE
fix(#2309): stop S3 flood crash — Sprintf OOM-safety + fit fingerprint pool to heap

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -69,8 +69,15 @@
 #define DEFAULT_COUNT_EXIT 4.0f
 #define DEFAULT_COUNT_MS 10000
 #define DEFAULT_COUNT_IDS ""
+// S3 boots with only ~100KB free (the IDF 5.4 / Arduino 3.2.1 SDK bump for DIO flash cut the
+// baseline from ~160KB). Each fingerprint costs ~560 bytes (object + id String + ~160-byte
+// AdaptivePercentileRSSI Reading[]), so the pool fills the heap and, once exhausted,
+// reports/JSON/MQTT crash — the #2309 flood crash. Measured: 200 exhausts at ~fp165; 60 runs
+// the 3-min flood clean. #2445 set 150 (thin margin vs the ~165 crash point); tighten to 100
+// (2× the ~50 devices a typical node tracks) to leave headroom for the report doc + WiFi/MQTT.
+// Not a leak — the pool is stable under eviction.
 #if defined(ESP32S3)
-#define DEFAULT_MAX_FINGERPRINTS 150
+#define DEFAULT_MAX_FINGERPRINTS 100
 #elif defined(ESP32C3) || defined(ESP32C6)
 #define DEFAULT_MAX_FINGERPRINTS 200
 #else


### PR DESCRIPTION
## The bug (measured, not guessed)

Under the BLE flood the S3 heap is **exhausted**, not raced: the 500ms HEAP_TRACE shows free falling ~560 bytes per fingerprint as the pool fills 0→~165 with no eviction (forgetMs=150s never triggers in 12s), then `alloc=285044 free=5740 largest=3316` and everything downstream aborts. The IDF 5.4 SDK bump (DIO flash) cut S3's free-heap baseline to ~100KB, so a 200-slot pool no longer fits.

**Leak vs pressure, settled behaviorally:** a cap-60 build runs the full 3-minute 40/s flood **clean** (~7000 evict/create cycles, no crash) while cap-200 crashes at ~12s. That rules out a per-eviction leak — it's pressure. `alloc_blocks` tracks fingerprint count 1:1; no blocks accumulate independently.

(`esp-aes: Failed to allocate` is WiFi WPA2 crypto starving on a 24-byte DMA alloc — a victim of exhaustion; the HIL has no known_irks/TLS so ESPresense runs no AES itself.)

## Fix — two genuine pieces, no magic-threshold hack

1. **`Sprintf`/`Stdprintf` OOM-safety** (#2446): `asprintf` returns -1 on OOM leaving `*s` indeterminate; the macros read/free that garbage → the decoded `LoadProhibited`/`std::length_error` Guru (via `getMac()` on every advert). Now they yield an empty string on failure.
2. **Cap S3 at 100 fingerprints** (from 200): fits the post-SDK heap with headroom (2× a typical ~50-device node). c3/c6 keep 200 (more free heap; they already pass).

## Follow-up (not here)
Reclaim capacity by right-sizing `AdaptivePercentileRSSI` (it eagerly allocates a 20-entry Reading[] even for a device seen once), and consider a shorter `forgetMs` so the pool evicts before filling under bursts.

Per merge policy: needs a real S3 hardware pass. Refs #2309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when memory allocation fails during string formatting.
  * ESP32-S3 devices now use a safer default limit of 100 stored fingerprints to reduce memory-related crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->