### PR TITLE
DIAG: trap esp32 heap corruptor (#2309)

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -69,10 +69,17 @@
 #define DEFAULT_COUNT_EXIT 4.0f
 #define DEFAULT_COUNT_MS 10000
 #define DEFAULT_COUNT_IDS ""
-// 200 on every flavor. Lazy AdaptivePercentileRSSI allocation (BleFingerprint::seen) drops the
-// per-fingerprint cost enough that even S3's ~100KB-free heap holds a full pool of seen-once
-// devices without exhausting (#2309). Chips that need less can still lower it via max_fingerprints.
+// The right-sized AdaptivePercentileRSSI buffer (grow-on-demand) cut per-fingerprint cost enough
+// that S3/C3/C6 hold a full 200 pool under the 40/s flood and pass HIL (verified: S3 fp=200,
+// "3m elapsed cleanly"). Classic esp32 is the tightest-heap flavor (its baseline leaves less free
+// than S3's ~100KB) and at 200 runs at ~0KB free — a legitimate std::string in the advert path
+// (NimBLEUUID->id) then aborts. Cap it at 100 (2x a typical ~50-device node) to keep headroom;
+// max_fingerprints is user-tunable if a given board proves it can go higher. (#2309)
+#if defined(ESP32S3) || defined(ESP32C3) || defined(ESP32C6)
 #define DEFAULT_MAX_FINGERPRINTS 200
+#else
+#define DEFAULT_MAX_FINGERPRINTS 100
+#endif
 
 // RX_ADJ_RSSI Defaults
 #ifdef M5STICK

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -69,13 +69,10 @@
 #define DEFAULT_COUNT_EXIT 4.0f
 #define DEFAULT_COUNT_MS 10000
 #define DEFAULT_COUNT_IDS ""
-#if defined(ESP32S3)
-#define DEFAULT_MAX_FINGERPRINTS 150
-#elif defined(ESP32C3) || defined(ESP32C6)
+// 200 on every flavor. Lazy AdaptivePercentileRSSI allocation (BleFingerprint::seen) drops the
+// per-fingerprint cost enough that even S3's ~100KB-free heap holds a full pool of seen-once
+// devices without exhausting (#2309). Chips that need less can still lower it via max_fingerprints.
 #define DEFAULT_MAX_FINGERPRINTS 200
-#else
-#define DEFAULT_MAX_FINGERPRINTS 60
-#endif
 
 // RX_ADJ_RSSI Defaults
 #ifdef M5STICK

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -70,13 +70,16 @@
 #define DEFAULT_COUNT_MS 10000
 #define DEFAULT_COUNT_IDS ""
 // The right-sized AdaptivePercentileRSSI buffer (grow-on-demand) cut per-fingerprint cost enough
-// that S3/C3/C6 hold a full 200 pool under the 40/s flood and pass HIL (verified: S3 fp=200,
-// "3m elapsed cleanly"). Classic esp32 is the tightest-heap flavor (its baseline leaves less free
-// than S3's ~100KB) and at 200 runs at ~0KB free — a legitimate std::string in the advert path
-// (NimBLEUUID->id) then aborts. Cap it at 100 (2x a typical ~50-device node) to keep headroom;
-// max_fingerprints is user-tunable if a given board proves it can go higher. (#2309)
-#if defined(ESP32S3) || defined(ESP32C3) || defined(ESP32C6)
+// that C3/C6 hold a full 200 pool under the 40/s flood and pass HIL reliably. S3 *can* reach 200
+// but only clears with ~1.7KB free — thinner than run-to-run WiFi/BT variance, so it's flaky
+// (2/3 HIL runs passed). Capped at 180 for a real (~10KB) margin so it passes every time. Classic
+// esp32 is the tightest-heap flavor and at 200 runs at ~0KB free, where a legitimate std::string
+// in the advert path (NimBLEUUID->id) aborts; capped at 100. All still user-tunable via
+// max_fingerprints, and all remain well above a typical ~50-device node. (#2309)
+#if defined(ESP32C3) || defined(ESP32C6)
 #define DEFAULT_MAX_FINGERPRINTS 200
+#elif defined(ESP32S3)
+#define DEFAULT_MAX_FINGERPRINTS 180
 #else
 #define DEFAULT_MAX_FINGERPRINTS 100
 #endif

--- a/lib/filtering/AdaptivePercentileRSSI.cpp
+++ b/lib/filtering/AdaptivePercentileRSSI.cpp
@@ -1,16 +1,18 @@
 #include "AdaptivePercentileRSSI.h"
 #include <Arduino.h>
 #include <algorithm>
+#include <new>
 
 AdaptivePercentileRSSI::AdaptivePercentileRSSI(uint32_t timeWindowMs, uint16_t initialMaxReadings)
     : timeWindowMs(timeWindowMs),
       maxReadings(initialMaxReadings),
+      allocated(min(INITIAL_ALLOCATED, initialMaxReadings)),
       head(0),
       tail(0),
       count(0),
       totalReadings(0),
       lastRateCheck(0) {
-    readings = new Reading[maxReadings];
+    readings = new (std::nothrow) Reading[allocated];
 }
 
 AdaptivePercentileRSSI::~AdaptivePercentileRSSI() {
@@ -20,19 +22,17 @@ AdaptivePercentileRSSI::~AdaptivePercentileRSSI() {
 AdaptivePercentileRSSI::AdaptivePercentileRSSI(const AdaptivePercentileRSSI& other)
     : timeWindowMs(other.timeWindowMs),
       maxReadings(other.maxReadings),
+      allocated(other.allocated),
       head(other.head),
       tail(other.tail),
       count(other.count),
       totalReadings(other.totalReadings),
       lastRateCheck(other.lastRateCheck) {
 
-    // Allocate new memory and copy the readings
-    readings = new Reading[maxReadings];
-
-    // Deep copy the readings array
-    for (uint16_t i = 0; i < maxReadings; i++) {
-        readings[i] = other.readings[i];
-    }
+    // Allocate new memory and deep-copy the (right-sized) buffer
+    readings = new (std::nothrow) Reading[allocated];
+    if (readings)
+        for (uint16_t i = 0; i < allocated; i++) readings[i] = other.readings[i];
 }
 
 AdaptivePercentileRSSI& AdaptivePercentileRSSI::operator=(const AdaptivePercentileRSSI& other) {
@@ -45,19 +45,17 @@ AdaptivePercentileRSSI& AdaptivePercentileRSSI::operator=(const AdaptivePercenti
         // Copy all member variables
         timeWindowMs = other.timeWindowMs;
         maxReadings = other.maxReadings;
+        allocated = other.allocated;
         head = other.head;
         tail = other.tail;
         count = other.count;
         totalReadings = other.totalReadings;
         lastRateCheck = other.lastRateCheck;
 
-        // Allocate new memory and copy the readings
-        readings = new Reading[maxReadings];
-
-        // Deep copy the readings array
-        for (uint16_t i = 0; i < maxReadings; i++) {
-            readings[i] = other.readings[i];
-        }
+        // Allocate new memory and deep-copy the (right-sized) buffer
+        readings = new (std::nothrow) Reading[allocated];
+        if (readings)
+            for (uint16_t i = 0; i < allocated; i++) readings[i] = other.readings[i];
     }
     return *this;
 }
@@ -66,15 +64,21 @@ void AdaptivePercentileRSSI::addMeasurement(float rssi) {
     uint32_t currentTime = millis();
     totalReadings++;
 
+    // Grow the buffer on demand toward the drop threshold, so a device holding few readings keeps
+    // a small array instead of pre-allocating all of maxReadings. Lossless: the set of readings
+    // kept (newest up to maxReadings, within the time window) is unchanged.
+    if (count == allocated && allocated < maxReadings)
+        growBuffer();
+
     // Add new reading to the circular buffer
-    if (count < maxReadings) {
+    if (count < allocated) {
         readings[head] = {rssi, currentTime};
-        head = (head + 1) % maxReadings;
+        head = (head + 1) % allocated;
         count++;
-    } else {
+    } else {  // buffer full at the drop threshold: overwrite oldest
         readings[head] = {rssi, currentTime};
-        head = (head + 1) % maxReadings;
-        tail = (tail + 1) % maxReadings;
+        head = (head + 1) % allocated;
+        tail = (tail + 1) % allocated;
     }
 
     // Remove expired readings
@@ -93,7 +97,7 @@ void AdaptivePercentileRSSI::removeExpiredReadings(uint32_t currentTime) {
 
         // Handle uint32_t overflow
         if (age > timeWindowMs && age < 0xFFFFFFFF - timeWindowMs) {
-            tail = (tail + 1) % maxReadings;
+            tail = (tail + 1) % allocated;
             count--;
         } else {
             break;
@@ -121,25 +125,47 @@ void AdaptivePercentileRSSI::adjustBufferSize(uint32_t currentTime) {
 }
 
 void AdaptivePercentileRSSI::resizeBuffer(uint16_t newSize) {
-    // Create new buffer
-    Reading* newReadings = new Reading[newSize];
+    // newSize is the new drop threshold. Growth toward a larger threshold is lazy (growBuffer);
+    // here we only shrink the allocation when the threshold drops below it, dropping the oldest
+    // readings that no longer fit — same as the old behavior, just without over-allocating.
+    maxReadings = newSize;
+    uint16_t newAlloc = min(allocated, newSize);
+    if (newAlloc < INITIAL_ALLOCATED) newAlloc = min((uint16_t)INITIAL_ALLOCATED, newSize);
+    if (newAlloc == allocated) return;
 
-    // Copy existing readings to new buffer
-    uint16_t newCount = min(count, newSize);
-    uint16_t oldIdx = (tail + count - newCount) % maxReadings; // Start from most recent if we need to drop old readings
+    Reading* newReadings = new (std::nothrow) Reading[newAlloc];
+    if (!newReadings) return;
 
+    uint16_t newCount = min(count, newAlloc);
+    uint16_t oldIdx = (tail + count - newCount) % allocated; // start from the most recent newCount
     for (uint16_t i = 0; i < newCount; i++) {
         newReadings[i] = readings[oldIdx];
-        oldIdx = (oldIdx + 1) % maxReadings;
+        oldIdx = (oldIdx + 1) % allocated;
     }
 
-    // Update pointers
     delete[] readings;
     readings = newReadings;
-    maxReadings = newSize;
-    head = newCount;
+    allocated = newAlloc;
+    head = newCount % newAlloc;
     tail = 0;
     count = newCount;
+}
+
+void AdaptivePercentileRSSI::growBuffer() {
+    uint16_t newAlloc = min((uint16_t)(allocated * 2), maxReadings);
+    if (newAlloc <= allocated) return;
+
+    Reading* newReadings = new (std::nothrow) Reading[newAlloc];
+    if (!newReadings) return; // OOM: keep the smaller buffer (drops oldest early, but never crashes)
+
+    for (uint16_t i = 0; i < count; i++)
+        newReadings[i] = readings[(tail + i) % allocated];
+
+    delete[] readings;
+    readings = newReadings;
+    allocated = newAlloc;
+    tail = 0;
+    head = count % newAlloc; // count < newAlloc here, so head = count
 }
 
 float AdaptivePercentileRSSI::getPercentileRSSI(float percentile) {
@@ -159,7 +185,7 @@ float AdaptivePercentileRSSI::getPercentileRSSI(float percentile) {
             values[validCount++] = readings[idx].rssi;
         }
 
-        idx = (idx + 1) % maxReadings;
+        idx = (idx + 1) % allocated;
     }
 
     if (validCount == 0) {
@@ -197,7 +223,7 @@ float AdaptivePercentileRSSI::getMedianIQR(float k /* = 1.5f */)
 
     for (uint16_t i = 0; i < count; ++i) {
         vals[i] = readings[idx].rssi;
-        idx = (idx + 1) % maxReadings;
+        idx = (idx + 1) % allocated;
     }
 
     // 2) Sort
@@ -243,7 +269,7 @@ float AdaptivePercentileRSSI::getAverageInterval() {
     if (count < 2) return 0;
 
     uint32_t firstTimestamp = readings[tail].timestamp;
-    uint32_t lastTimestamp = readings[(head + maxReadings - 1) % maxReadings].timestamp;
+    uint32_t lastTimestamp = readings[(head + allocated - 1) % allocated].timestamp;
 
     return (lastTimestamp - firstTimestamp) / (float)(count - 1);
 }
@@ -275,7 +301,7 @@ float AdaptivePercentileRSSI::getRSSIVariance() {
             validCount++;
         }
 
-        idx = (idx + 1) % maxReadings;
+        idx = (idx + 1) % allocated;
     }
 
     if (validCount < 2) return 0;
@@ -314,7 +340,7 @@ float AdaptivePercentileRSSI::getDistanceVariance(float refRSSI, float pathLossE
             validCount++;
         }
 
-        idx = (idx + 1) % maxReadings;
+        idx = (idx + 1) % allocated;
     }
 
     if (validCount < 2) return 0;

--- a/lib/filtering/AdaptivePercentileRSSI.h
+++ b/lib/filtering/AdaptivePercentileRSSI.h
@@ -29,11 +29,13 @@ private:
 
     static constexpr uint16_t MIN_READINGS = 10;
     static constexpr uint16_t MAX_READINGS = 200;
+    static constexpr uint16_t INITIAL_ALLOCATED = 4; // grow on demand from here toward maxReadings
     static constexpr uint32_t RATE_CHECK_INTERVAL_MS = 10000; // Check rate every 10 seconds
 
-    Reading* readings;      // Dynamic array for readings
+    Reading* readings;      // Dynamic array for readings (sized `allocated`, grown on demand)
     uint32_t timeWindowMs;  // Time window in milliseconds
-    uint16_t maxReadings;   // Current maximum readings
+    uint16_t maxReadings;   // Drop threshold: newest `maxReadings` readings are kept (rate-adjusted)
+    uint16_t allocated;     // Actual buffer size; grows from INITIAL_ALLOCATED up to maxReadings
     uint16_t head;          // Index for newest reading
     uint16_t tail;          // Index for oldest reading
     uint16_t count;         // Current number of readings
@@ -43,6 +45,7 @@ private:
     void removeExpiredReadings(uint32_t currentTime);
     void adjustBufferSize(uint32_t currentTime);
     void resizeBuffer(uint16_t newSize);
+    void growBuffer();  // double `allocated` toward maxReadings, re-linearizing the buffer
 };
 
 #endif

--- a/lib/utils/string_utils.cpp
+++ b/lib/utils/string_utils.cpp
@@ -25,6 +25,12 @@ std::string lowertrim(std::string str, char toTrim)
 
 static std::string normalizeWordSeparators(const std::string &text, char replacement)
 {
+    // DIAG(#2309): a garbage text.size() here is the esp32 abort (length_error with 53KB free).
+    // Log the implausible size + bail instead of throwing, so the flood keeps running and we see it.
+    if (text.size() > 512) {
+        ets_printf("[CORRUPT] normalizeWordSeparators size=%u data=%p\n", (unsigned)text.size(), (const void *)text.data());
+        return std::string();
+    }
     std::string out;
     out.reserve(text.size());
     bool lastWasReplacement = false;

--- a/lib/utils/string_utils.h
+++ b/lib/utils/string_utils.h
@@ -6,8 +6,12 @@
 
 #define CHIPID ((unsigned int)(ESP.getEfuseMac() >> 24))
 #define ESPMAC (Sprintf("%06x", CHIPID))
-#define Sprintf(f, ...) ({ char* s; asprintf(&s, f, __VA_ARGS__); const String r = s; free(s); r; })
-#define Stdprintf(f, ...) ({ char* s; asprintf(&s, f, __VA_ARGS__); const std::string r = s; free(s); r; })
+// asprintf mallocs *s and returns -1 on OOM leaving *s indeterminate. The old form read an
+// uninitialized s (String/std::string from a garbage pointer -> strlen/copy fault) and free()'d
+// it -> the #2309 S3 Guru (LoadProhibited / std::length_error) once the heap was exhausted.
+// Guard: only touch/free s when asprintf succeeded; otherwise yield an empty string.
+#define Sprintf(f, ...) ({ char* s = nullptr; String r; if (asprintf(&s, f, __VA_ARGS__) >= 0 && s) { r = s; free(s); } r; })
+#define Stdprintf(f, ...) ({ char* s = nullptr; std::string r; if (asprintf(&s, f, __VA_ARGS__) >= 0 && s) { r = s; free(s); } r; })
 
 std::string slugify(const std::string& text);
 String slugify(const String& text);

--- a/platformio.ini
+++ b/platformio.ini
@@ -61,7 +61,7 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer@3.9.3
   https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.5
   https://github.com/ESPresense/NimBLE-Arduino.git#1.4.0
-  https://github.com/ESPresense/async-mqtt-client.git#v0.9.3
+  https://github.com/ESPresense/async-mqtt-client.git#v0.9.4
   bblanchon/ArduinoJson@^6.21.5
   kitesurfer1404/WS2812FX@^1.4.2
 board_build.partitions = partitions_singleapp.csv
@@ -114,7 +114,7 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer@3.9.3
   https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.4
   h2zero/NimBLE-Arduino@^2.3.7
-  https://github.com/ESPresense/async-mqtt-client.git#v0.9.3
+  https://github.com/ESPresense/async-mqtt-client.git#v0.9.4
   bblanchon/ArduinoJson@^6.21.5
   kitesurfer1404/WS2812FX@^1.4.2
 build_flags =
@@ -148,7 +148,7 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer@3.9.3
   https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.5
   h2zero/NimBLE-Arduino@^2.3.7
-  https://github.com/ESPresense/async-mqtt-client.git#v0.9.3
+  https://github.com/ESPresense/async-mqtt-client.git#v0.9.4
   bblanchon/ArduinoJson@^6.21.5
   kitesurfer1404/WS2812FX@^1.4.2
 build_flags =

--- a/platformio.ini
+++ b/platformio.ini
@@ -381,4 +381,4 @@ platform = native
 test_framework = unity
 lib_compat_mode = off
 lib_deps = bblanchon/ArduinoJson@^6.21.5
-build_flags = -std=gnu++17 -Wall -Wextra
+build_flags = -std=gnu++17 -Wall -Wextra -I test/mocks

--- a/src/BleFingerprint.cpp
+++ b/src/BleFingerprint.cpp
@@ -1,6 +1,7 @@
 #include "BleFingerprint.h"
 
 #include <math.h>
+#include <new>
 #include <stdint.h>
 
 #include "BleFingerprintCollection.h"
@@ -45,7 +46,7 @@ void BleFingerprint::setInitial(const BleFingerprint &other) {
     distVar = other.distVar;
     raw = other.raw;
     if (other.adaptivePercentileRSSI)
-        adaptivePercentileRSSI = std::unique_ptr<AdaptivePercentileRSSI>(new AdaptivePercentileRSSI(*other.adaptivePercentileRSSI));
+        adaptivePercentileRSSI = std::unique_ptr<AdaptivePercentileRSSI>(new (std::nothrow) AdaptivePercentileRSSI(*other.adaptivePercentileRSSI));
     else
         adaptivePercentileRSSI.reset();
 }
@@ -577,7 +578,7 @@ bool BleFingerprint::seen(BLEAdvertisedDevice *advertisedDevice) {
     // what stopped the pool fitting 200 on the ~100KB-free S3. Defer it to the 2nd sighting and
     // use the raw reading until then; real (repeatedly-seen) devices still get the full filter.
     if (!adaptivePercentileRSSI && seenCount >= 2)
-        adaptivePercentileRSSI = std::unique_ptr<AdaptivePercentileRSSI>(new AdaptivePercentileRSSI());
+        adaptivePercentileRSSI = std::unique_ptr<AdaptivePercentileRSSI>(new (std::nothrow) AdaptivePercentileRSSI());
     if (adaptivePercentileRSSI) {
         adaptivePercentileRSSI->addMeasurement(adjusted);
         rssi = adaptivePercentileRSSI->getMedianIQR();

--- a/src/BleFingerprint.cpp
+++ b/src/BleFingerprint.cpp
@@ -164,8 +164,13 @@ void BleFingerprint::fingerprint(const NimBLEAdvertisedDevice *advertisedDevice)
 void BleFingerprint::fingerprint(BLEAdvertisedDevice *advertisedDevice) {
 #endif
     if (advertisedDevice->haveName()) {
-        const std::string name = advertisedDevice->getName();
-        if (!name.empty()) setId(String("name:") + kebabify(name).c_str(), ID_TYPE_NAME, String(name.c_str()));
+        const std::string &nameSrc = advertisedDevice->getName();  // DIAG(#2309): ref, no copy yet
+        if (nameSrc.size() > 512) {
+            ets_printf("[CORRUPT] getName size=%u data=%p mac=%s\n", (unsigned)nameSrc.size(), (const void *)nameSrc.data(), getMac().c_str());
+        } else if (!nameSrc.empty()) {
+            const std::string name = nameSrc;
+            setId(String("name:") + kebabify(name).c_str(), ID_TYPE_NAME, String(name.c_str()));
+        }
     }
 
     if (advertisedDevice->getAdvType() > 0)
@@ -380,7 +385,9 @@ void BleFingerprint::fingerprintServiceData(BLEAdvertisedDevice *advertisedDevic
     String fingerprint = "";
     for (int i = 0; i < serviceDataCount; i++) {
         BLEUUID uuid = advertisedDevice->getServiceDataUUID(i);
-        std::string strServiceData = advertisedDevice->getServiceData(i);
+        const std::string &sdSrc = advertisedDevice->getServiceData(i);  // DIAG(#2309)
+        if (sdSrc.size() > 512) { ets_printf("[CORRUPT] getServiceData i=%d/%u size=%u mac=%s\n", i, (unsigned)serviceDataCount, (unsigned)sdSrc.size(), getMac().c_str()); continue; }
+        std::string strServiceData = sdSrc;
 #ifdef VERBOSE
         Log.printf("Verbose | %s | %-58s%.1fdBm SD: %s/%s\r\n", getMac().c_str(), getId().c_str(), rssi, uuid.toString().c_str(), hexStr(strServiceData).c_str());
 #endif
@@ -475,7 +482,9 @@ void BleFingerprint::fingerprintManufactureData(const NimBLEAdvertisedDevice *ad
 #else
 void BleFingerprint::fingerprintManufactureData(BLEAdvertisedDevice *advertisedDevice, bool haveTxPower, int8_t txPower) {
 #endif
-    std::string strManufacturerData = advertisedDevice->getManufacturerData();
+    const std::string &mdSrc = advertisedDevice->getManufacturerData();  // DIAG(#2309)
+    if (mdSrc.size() > 512) { ets_printf("[CORRUPT] getManufacturerData size=%u mac=%s\n", (unsigned)mdSrc.size(), getMac().c_str()); return; }
+    std::string strManufacturerData = mdSrc;
 #ifdef VERBOSE
     Log.printf("Verbose | %s | %-58s%.1fdBm MD: %s\r\n", getMac().c_str(), getId().c_str(), rssi, hexStr(strManufacturerData).c_str());
 #endif

--- a/src/BleFingerprint.cpp
+++ b/src/BleFingerprint.cpp
@@ -570,13 +570,25 @@ bool BleFingerprint::seen(BLEAdvertisedDevice *advertisedDevice) {
     if (ignore || hidden) return false;
 
     raw = advertisedDevice->getRSSI();
-    if (!adaptivePercentileRSSI)
+    auto adjusted = raw - BleFingerprintCollection::rxAdjRssi;
+    // Lazy filter: a device seen once can't be smoothed anyway, and under churn (a room full of
+    // rotating-MAC phones, or #2309's flood) the pool fills with seen-once devices whose
+    // ~200-byte AdaptivePercentileRSSI (object + Reading[]) is pure waste — that overhead is
+    // what stopped the pool fitting 200 on the ~100KB-free S3. Defer it to the 2nd sighting and
+    // use the raw reading until then; real (repeatedly-seen) devices still get the full filter.
+    if (!adaptivePercentileRSSI && seenCount >= 2)
         adaptivePercentileRSSI = std::unique_ptr<AdaptivePercentileRSSI>(new AdaptivePercentileRSSI());
-    adaptivePercentileRSSI->addMeasurement(raw - BleFingerprintCollection::rxAdjRssi);
-    rssi = adaptivePercentileRSSI->getMedianIQR();
-    rssiVar = adaptivePercentileRSSI->getRSSIVariance();
+    if (adaptivePercentileRSSI) {
+        adaptivePercentileRSSI->addMeasurement(adjusted);
+        rssi = adaptivePercentileRSSI->getMedianIQR();
+        rssiVar = adaptivePercentileRSSI->getRSSIVariance();
+        distVar = adaptivePercentileRSSI->getDistanceVariance(get1mRssi(), BleFingerprintCollection::absorption);
+    } else {
+        rssi = adjusted;
+        rssiVar = 0;
+        distVar = 0;
+    }
     dist = pow(10, float(get1mRssi() - rssi) / (10.0f * BleFingerprintCollection::absorption));
-    distVar = adaptivePercentileRSSI->getDistanceVariance(get1mRssi(), BleFingerprintCollection::absorption);
 
     if (!added) {
         added = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -514,7 +514,9 @@ void reportLoop() {
     GUI::Count(count);
 
     yield();
+    if (!heap_caps_check_integrity_all(true)) ets_printf("[CORRUPT] heap bad BEFORE sendTelemetry fp=%u\n", (unsigned)fingerprintCount);
     sendTelemetry(totalSeen, totalFpSeen, totalFpQueried, totalFpReported, count, fingerprintCount);
+    if (!heap_caps_check_integrity_all(true)) ets_printf("[CORRUPT] heap bad AFTER sendTelemetry fp=%u\n", (unsigned)fingerprintCount);
     yield();
 
     auto reported = 0;
@@ -535,6 +537,7 @@ void reportLoop() {
             totalFpReported++;
             reported++;
         }
+        if (!heap_caps_check_integrity_all(true)) ets_printf("[CORRUPT] heap bad AFTER reportDevice mac=%s\n", f->getMac().c_str());
         BleFingerprintCollection::Release(lease);
         yield();
     }

--- a/test/mocks/Arduino.h
+++ b/test/mocks/Arduino.h
@@ -1,0 +1,13 @@
+#pragma once
+// Minimal Arduino shim so AdaptivePercentileRSSI can be unit-tested on the native platform.
+#include <cstdint>
+#include <algorithm>
+#include <cmath>
+extern uint32_t g_now;
+inline uint32_t millis() { return g_now; }
+using std::min;
+using std::max;
+using std::ceil;
+using std::abs;
+template <typename T>
+inline T constrain(T x, T lo, T hi) { return x < lo ? lo : (x > hi ? hi : x); }

--- a/test/test_native_apr/test_apr.cpp
+++ b/test/test_native_apr/test_apr.cpp
@@ -1,0 +1,84 @@
+// Losslessness guard for the right-sized (grow-on-demand) AdaptivePercentileRSSI buffer.
+// The buffer now starts small and grows toward maxReadings on demand instead of pre-allocating
+// Reading[maxReadings]. This test proves that change keeps the SAME readings and produces the
+// SAME median/IQR as a direct reference — i.e. it's a pure memory win, not a behavior change.
+#include <unity.h>
+#include <cstdint>
+#include <cmath>
+#include <vector>
+#include <algorithm>
+
+uint32_t g_now = 0;
+
+#include "AdaptivePercentileRSSI.h"
+
+// Reference Tukey-fenced mean, matching getMedianIQR's algorithm, over an explicit value set.
+static float refMedianIQR(std::vector<float> v, float k = 1.5f) {
+    if (v.empty()) return 0.0f;
+    std::sort(v.begin(), v.end());
+    int n = (int)v.size();
+    auto interp = [&](float p) { float pos = p * (n - 1); int lo = (int)pos; float f = pos - lo;
+        return (lo + 1 < n) ? v[lo] * (1 - f) + v[lo + 1] * f : v[lo]; };
+    float q1 = interp(0.25f), med = interp(0.5f), q3 = interp(0.75f), iqr = q3 - q1;
+    float lo = q1 - k * iqr, hi = q3 + k * iqr;
+    float sum = 0; int surv = 0;
+    for (float x : v) if (x >= lo && x <= hi) { sum += x; surv++; }
+    return surv ? sum / surv : med;
+}
+
+void test_few_readings_small_buffer(void) {  // the flood case: seen a couple times
+    AdaptivePercentileRSSI f(15000, 20);
+    std::vector<float> vals = {-60, -62};
+    g_now = 0;
+    for (float x : vals) { f.addMeasurement(x); g_now += 100; }
+    TEST_ASSERT_EQUAL_UINT16(2, f.getReadingCount());
+    TEST_ASSERT_FLOAT_WITHIN(1e-3, refMedianIQR(vals), f.getMedianIQR());
+}
+
+void test_over_threshold_holds_newest(void) {  // >maxReadings: keep newest 20, drop oldest
+    AdaptivePercentileRSSI f(15000, 20);
+    std::vector<float> all;
+    g_now = 0;
+    for (int i = 0; i < 30; i++) { float x = -50 - (i % 7); all.push_back(x); f.addMeasurement(x); g_now += 100; }
+    TEST_ASSERT_EQUAL_UINT16(20, f.getReadingCount());
+    std::vector<float> held(all.end() - 20, all.end());
+    TEST_ASSERT_FLOAT_WITHIN(1e-3, refMedianIQR(held), f.getMedianIQR());
+}
+
+void test_grow_path_exact(void) {  // buffer grows 4->8->16->20, all 20 held
+    AdaptivePercentileRSSI f(15000, 20);
+    std::vector<float> all;
+    g_now = 0;
+    for (int i = 0; i < 20; i++) { float x = -40 - i; all.push_back(x); f.addMeasurement(x); g_now += 50; }
+    TEST_ASSERT_EQUAL_UINT16(20, f.getReadingCount());
+    TEST_ASSERT_FLOAT_WITHIN(1e-3, refMedianIQR(all), f.getMedianIQR());
+}
+
+void test_window_expiry(void) {  // readings older than the 15s window drop out
+    AdaptivePercentileRSSI f(15000, 20);
+    g_now = 0;
+    f.addMeasurement(-90); g_now += 20000;
+    std::vector<float> recent = {-55, -57, -56};
+    for (float x : recent) { f.addMeasurement(x); g_now += 100; }
+    TEST_ASSERT_FLOAT_WITHIN(1e-3, refMedianIQR(recent), f.getMedianIQR());
+}
+
+void test_copy_preserves(void) {  // copy ctor keeps the right-sized buffer + outputs
+    AdaptivePercentileRSSI f(15000, 20);
+    std::vector<float> vals = {-61, -63, -60, -62, -59};
+    g_now = 0;
+    for (float x : vals) { f.addMeasurement(x); g_now += 100; }
+    AdaptivePercentileRSSI g = f;
+    TEST_ASSERT_EQUAL_UINT16(5, g.getReadingCount());
+    TEST_ASSERT_FLOAT_WITHIN(1e-3, refMedianIQR(vals), g.getMedianIQR());
+}
+
+int main(int, char **) {
+    UNITY_BEGIN();
+    RUN_TEST(test_few_readings_small_buffer);
+    RUN_TEST(test_over_threshold_holds_newest);
+    RUN_TEST(test_grow_path_exact);
+    RUN_TEST(test_window_expiry);
+    RUN_TEST(test_copy_preserves);
+    return UNITY_END();
+}


### PR DESCRIPTION
Diagnostic build to pinpoint the esp32 corruption behind the length_error abort (garbage string length with 53KB free). Not for merge. Heap-integrity brackets in reportLoop + log/bail at the throw site. Refs #2309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Increased default fingerprint capacity for supported ESP32 variants while retaining configuration options.
  - Improved RSSI filtering to retain recent readings and adapt buffer usage as needed.
  - Improved first-sighting signal handling for more consistent device measurements.

- **Bug Fixes**
  - Added safeguards for oversized data and memory-allocation failures.
  - Improved handling of invalid device data.
  - Added heap-integrity monitoring during telemetry and device reporting.

- **Tests**
  - Expanded coverage for RSSI buffering, retention, expiration, copying, and statistical calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->