### PR TITLE
TEST: main baseline esp32 cap100 (#2309)

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -74,7 +74,7 @@
 #elif defined(ESP32C3) || defined(ESP32C6)
 #define DEFAULT_MAX_FINGERPRINTS 200
 #else
-#define DEFAULT_MAX_FINGERPRINTS 60
+#define DEFAULT_MAX_FINGERPRINTS 100  // baseline test: match branch cap to isolate code vs cap
 #endif
 
 // RX_ADJ_RSSI Defaults


### PR DESCRIPTION
Baseline: plain main + esp32 cap=100 to determine if the corruption abort is pre-existing or introduced by the fix branch. Not for merge. Refs #2309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the default maximum number of stored fingerprints from 60 to 100 for supported generic configurations.
  * ESP32S3, ESP32C3, and ESP32C6 defaults remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->