### PR TITLE
fix(#2309): reboot on a fragmented heap, not just an empty one

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,6 +38,11 @@ build_flags =
   -D SCAN_TASK_STACK_SIZE=2562
   -D ARDUINO_LOOP_STACK_SIZE=6500
   -D MQTT_MIN_FREE_MEMORY=12192
+; Largest-contiguous-block floor for the low-heap watchdog (#2309). Above the 2312 byte
+; allocation that 93% of the failed allocations in that report asked for, so a fragmented
+; node reboots before that class of allocation starts failing; far below the ~100KB a
+; healthy S3 reports post-setup, so it never trips on a working node.
+  -D MIN_MAX_ALLOC_HEAP=4096
   -D CONFIG_ASYNC_TCP_USE_WDT=0
   -D CONFIG_BT_NIMBLE_MSYS1_BLOCK_COUNT=20
   -D BLE_GATTC_UNRESPONSIVE_TIMEOUT_MS=2000

--- a/src/HeapWatchdog.h
+++ b/src/HeapWatchdog.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+
+// The low-heap reboot decision, kept apart from main.cpp so it can be tested without
+// hardware. See loop() for the caller.
+//
+// #2309 showed why free heap alone is the wrong number to guard. A node ran 6.8h with
+// telemetry failing from 3.8h onward and never rebooted: it sat at 16-20KB free, above
+// MQTT_MIN_FREE_MEMORY, while the largest free block had already fallen under the 2312 byte
+// allocation that 93% of its failed allocations asked for. Fragmented-but-not-empty looks
+// healthy to a free-heap check and is just as dead in practice, so it gets its own floor.
+enum class HeapTrip : uint8_t {
+    None,
+    FreeHeap,  // total free heap exhausted
+    MaxAlloc,  // heap fragmented: largest contiguous block too small to serve a real request
+};
+
+// One slow-loop tick. Returns the condition that has held for `threshold` consecutive
+// ticks (12 x 5s = 60s of debounce), or None.
+//
+// `passes` is caller-owned state and is reset by any healthy tick, so a node that dips and
+// recovers does not accumulate toward a reboot. Both floors share the counter: a heap that
+// alternates between the two failure modes is not healthy in between, and restarting the
+// count on each alternation would let it limp indefinitely — the exact behaviour this
+// exists to stop.
+//
+// Reporting *which* floor tripped is the point of the enum rather than a bool. The
+// complaint in #2309 was a serial log that said "Low memory" and never said why the node
+// then died, so the caller has to be able to name the condition in the reboot line.
+inline HeapTrip heapWatchdogTick(uint32_t freeHeap, uint32_t maxAlloc,
+                                 uint32_t freeFloor, uint32_t maxAllocFloor,
+                                 uint8_t &passes, uint8_t threshold = 12) {
+    bool const freeLow = freeHeap < freeFloor;
+    bool const allocLow = maxAlloc < maxAllocFloor;
+
+    if (!freeLow && !allocLow) {
+        passes = 0;
+        return HeapTrip::None;
+    }
+
+    if (passes < UINT8_MAX) passes++;
+    if (passes < threshold) return HeapTrip::None;
+
+    // Free heap first when both are low: it is the stronger statement about the node, and
+    // an empty heap is necessarily also a fragmented one.
+    return freeLow ? HeapTrip::FreeHeap : HeapTrip::MaxAlloc;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -678,7 +678,11 @@ void loop() {
     if (millis() - lastSlowLoop > 5000) {
         lastSlowLoop = millis();
         auto freeHeap = ESP.getFreeHeap();
-        if (freeHeap < 20000) Log.printf("Low memory: %lu bytes free\r\n", static_cast<unsigned long>(freeHeap));
+        auto maxAlloc = ESP.getMaxAllocHeap();
+        // maxAlloc as well as freeHeap: #2309's node logged "Low memory: ~20000 bytes free"
+        // for twenty minutes without the one number that explained the crash — its largest
+        // free block was already under the 2312 byte request that kept failing.
+        if (freeHeap < 20000) Log.printf("Low memory: %lu bytes free, largest block %lu\r\n", static_cast<unsigned long>(freeHeap), static_cast<unsigned long>(maxAlloc));
         if (freeHeap > 40000) Updater::Loop();
 
         // ponytail: watchdog, not a leak fix. A heap-starved node limps forever (mqtt and
@@ -686,13 +690,18 @@ void loop() {
         // threshold mqtt already refuses to publish under. Same escape hatch as the stuck
         // BLE controller restart in BleFingerprintCollection::CleanupOldFingerprints().
         static uint8_t lowHeapPasses = 0;
-        if (freeHeap < MQTT_MIN_FREE_MEMORY) {
-            if (++lowHeapPasses >= 12) {
+        switch (heapWatchdogTick(freeHeap, maxAlloc, MQTT_MIN_FREE_MEMORY, MIN_MAX_ALLOC_HEAP, lowHeapPasses)) {
+            case HeapTrip::FreeHeap:
                 Log.printf("Out of memory for 60s (%lu bytes free), restarting\r\n", static_cast<unsigned long>(freeHeap));
                 ESP.restart();
-            }
-        } else
-            lowHeapPasses = 0;
+                break;
+            case HeapTrip::MaxAlloc:
+                Log.printf("Heap too fragmented for 60s (largest block %lu, %lu bytes free), restarting\r\n", static_cast<unsigned long>(maxAlloc), static_cast<unsigned long>(freeHeap));
+                ESP.restart();
+                break;
+            case HeapTrip::None:
+                break;
+        }
     }
     GUI::Loop();
     Motion::Loop();

--- a/src/main.h
+++ b/src/main.h
@@ -16,6 +16,7 @@
 #include "CAN.h"
 #include "Enrollment.h"
 #include "GUI.h"
+#include "HeapWatchdog.h"
 #include "HttpReleaseUpdate.h"
 #include "HttpWebServer.h"
 #include "Motion.h"

--- a/test/test_native_watchdog/test_heap_watchdog.cpp
+++ b/test/test_native_watchdog/test_heap_watchdog.cpp
@@ -1,0 +1,101 @@
+// Low-heap watchdog trip decision: the debounce, and which floor gets reported.
+//
+// #2309's node never rebooted because the watchdog only ever looked at free heap, so the
+// case that matters most here is a heap with plenty free and no contiguous block left.
+#include <unity.h>
+
+#include "../../src/HeapWatchdog.h"
+
+namespace {
+
+constexpr uint32_t FREE_FLOOR = 12192;  // MQTT_MIN_FREE_MEMORY
+constexpr uint32_t ALLOC_FLOOR = 4096;  // MIN_MAX_ALLOC_HEAP
+
+HeapTrip tick(uint32_t freeHeap, uint32_t maxAlloc, uint8_t &passes) {
+    return heapWatchdogTick(freeHeap, maxAlloc, FREE_FLOOR, ALLOC_FLOOR, passes);
+}
+
+// Run `count` identical ticks and return the last verdict.
+HeapTrip run(uint32_t freeHeap, uint32_t maxAlloc, uint8_t &passes, int count) {
+    HeapTrip last = HeapTrip::None;
+    for (int i = 0; i < count; i++) last = tick(freeHeap, maxAlloc, passes);
+    return last;
+}
+
+void test_healthy_never_trips(void) {
+    uint8_t passes = 0;
+    // A whole day of healthy slow-loop ticks.
+    TEST_ASSERT_TRUE(HeapTrip::None == run(120000, 90000, passes, 17280));
+    TEST_ASSERT_EQUAL_UINT8(0, passes);
+}
+
+void test_free_heap_trips_at_twelve_not_eleven(void) {
+    uint8_t passes = 0;
+    TEST_ASSERT_TRUE(HeapTrip::None == run(8000, 90000, passes, 11));
+    TEST_ASSERT_TRUE(HeapTrip::FreeHeap == tick(8000, 90000, passes));
+}
+
+// The #2309 case: 20KB free is above the free floor and looks fine, but nothing contiguous
+// is left. The old watchdog sat here until the node Guru'd.
+void test_fragmentation_trips_while_free_heap_looks_healthy(void) {
+    uint8_t passes = 0;
+    TEST_ASSERT_TRUE(HeapTrip::None == run(20000, 2000, passes, 11));
+    TEST_ASSERT_TRUE(HeapTrip::MaxAlloc == tick(20000, 2000, passes));
+}
+
+void test_free_heap_wins_when_both_are_low(void) {
+    uint8_t passes = 0;
+    // An empty heap is necessarily a fragmented one; report the stronger statement.
+    TEST_ASSERT_TRUE(HeapTrip::FreeHeap == run(1000, 500, passes, 12));
+}
+
+void test_one_healthy_tick_resets_the_count(void) {
+    uint8_t passes = 0;
+    run(8000, 90000, passes, 11);
+    TEST_ASSERT_TRUE(HeapTrip::None == tick(120000, 90000, passes));
+    TEST_ASSERT_EQUAL_UINT8(0, passes);
+    // Back to starving: a full fresh debounce is required, not one more tick.
+    TEST_ASSERT_TRUE(HeapTrip::None == run(8000, 90000, passes, 11));
+    TEST_ASSERT_TRUE(HeapTrip::FreeHeap == tick(8000, 90000, passes));
+}
+
+// Alternating between the two failure modes is not recovery, and must not defer the reboot.
+void test_alternating_conditions_still_trip(void) {
+    uint8_t passes = 0;
+    HeapTrip last = HeapTrip::None;
+    for (int i = 0; i < 12; i++)
+        last = i % 2 ? tick(20000, 2000, passes)   // fragmented
+                     : tick(8000, 90000, passes);  // empty
+    TEST_ASSERT_TRUE(HeapTrip::None != last);
+}
+
+// At the floor exactly is healthy; one byte under is not.
+void test_boundaries_are_exclusive(void) {
+    uint8_t passes = 0;
+    TEST_ASSERT_TRUE(HeapTrip::None == run(FREE_FLOOR, ALLOC_FLOOR, passes, 100));
+    TEST_ASSERT_EQUAL_UINT8(0, passes);
+    TEST_ASSERT_TRUE(HeapTrip::MaxAlloc == run(FREE_FLOOR, ALLOC_FLOOR - 1, passes, 12));
+}
+
+// A node left tripping without rebooting must not wrap its counter back under the
+// threshold and go quiet.
+void test_counter_saturates_rather_than_wrapping(void) {
+    uint8_t passes = 0;
+    TEST_ASSERT_TRUE(HeapTrip::MaxAlloc == run(20000, 2000, passes, 1000));
+    TEST_ASSERT_EQUAL_UINT8(UINT8_MAX, passes);
+}
+
+}  // namespace
+
+int main(int, char **) {
+    UNITY_BEGIN();
+    RUN_TEST(test_healthy_never_trips);
+    RUN_TEST(test_free_heap_trips_at_twelve_not_eleven);
+    RUN_TEST(test_fragmentation_trips_while_free_heap_looks_healthy);
+    RUN_TEST(test_free_heap_wins_when_both_are_low);
+    RUN_TEST(test_one_healthy_tick_resets_the_count);
+    RUN_TEST(test_alternating_conditions_still_trip);
+    RUN_TEST(test_boundaries_are_exclusive);
+    RUN_TEST(test_counter_saturates_rather_than_wrapping);
+    return UNITY_END();
+}


### PR DESCRIPTION
First of three PRs off #2309. This one is independent of the leak hunt and is the pressing part: **the node in that report went dark for three hours and never rebooted.**

## What the log shows

Garkus98's 6.8 h `putty.log` (build `5840269`, POWERON → crash):

| t (s) | event |
|---|---|
| 0 | `Post-Setup Free Mem: 162448` |
| 13842 | first `sendTelemetry(): Error after 10 tries` |
| 17694 | first `heap_caps_malloc_prefer failed` — 2312 B, caps 0x1800 |
| 23321 | first `Low memory: ~20000 bytes free` |
| 24635 | `Guru Meditation ... Core 1 panic'ed (Double exception)` during WiFi reconnect |

Telemetry stopped working at 3.8 h. From 4.9 h onward **3156 of 3395 failed allocations were the same 2312 B request, while ~25 KB was still free** — the largest contiguous block had already fallen under the request size. The node then sat at 16–20 KB free for twenty-plus minutes and Guru'd.

The watchdog at `main.cpp` only trips below `MQTT_MIN_FREE_MEMORY` (12192). It saw a healthy number the entire way down. **It was guarding the wrong number:** fragmented-but-not-empty looks fine to a free-heap check and is just as dead in practice.

## The change

- `ESP.getMaxAllocHeap()` below `MIN_MAX_ALLOC_HEAP` becomes a second trip condition on the **same** 12-pass / 60 s debounce as the existing free-heap floor. The reboot line names which floor tripped.
- `MIN_MAX_ALLOC_HEAP=4096` in `[common] build_flags`, beside `MQTT_MIN_FREE_MEMORY`. Above the 2312 B allocation that dominates the failures — so a fragmented node reboots *before* that class of allocation starts failing — and far below the ~100 KB a healthy S3 reports post-setup.
- Both floors share the debounce counter deliberately. A heap alternating between the two failure modes is not healthy in between, and restarting the count on each alternation would let it limp indefinitely, which is the exact behaviour this exists to stop.
- The low-memory log line now carries the largest block too. `Low memory: ~20000 bytes free` omitted the one number that explained the crash.

## Why a new header

The decision moves to `src/HeapWatchdog.h` so it can be tested without hardware, following the split `TeleJson.h` already uses. Firing this watchdog on a real device needs a heap state HIL cannot produce on demand, so the debounce, the reset-on-recovery behaviour, the saturation guard and the fragmented-but-not-empty case are covered by `test/test_native_watchdog` instead.

## Verification

- `test/test_native_watchdog/` — 8 cases, all passing. Neither condition trips across a simulated day of healthy ticks; each trips at exactly 12 consecutive passes and not at 11; one healthy tick resets the count; `HeapTrip::FreeHeap` wins when both are low; the counter saturates rather than wrapping back under the threshold.
- **Note on how those were run:** PlatformIO is not available in this environment, so the test file was compiled and run with `g++ -std=gnu++17 -Wall -Wextra` against a minimal Unity shim rather than via `pio test -e native`. The assertions and the file layout match the existing `test_native_tele` convention; please confirm under real `pio test -e native`. Firmware builds (`pio run -e esp32s3`, `-e esp32`) were **not** run here for the same reason — CI covers them.
- **HIL, PR event (180 s × 4 devices):** must be green. A false trip at healthy heap reboots the device mid-run and fails the monitor — that is the guard against the floor being too high.
- **HIL, 8 h cron on main after merge:** the real proof that 4096 never trips on a healthy node over a long run. If a device restarts with the new `Heap too fragmented` line while its heap numbers look fine, the floor comes down.

Does not attempt to fix the leak — that is PRs 2 and 3. This makes the failure mode recoverable regardless of which path gets there, and note that #2446 landed after the build in this log, so the double exception itself may already be fixed by another route.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJShR6eN7MCm2tGDUwLdKt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved low-memory monitoring by detecting both insufficient free heap and heap fragmentation.
  * Added safeguards to prevent device restarts from brief or temporary memory dips.
  * Enhanced diagnostic logging to identify the specific memory condition that triggered a restart.
* **Tests**
  * Added coverage for memory thresholds, recovery behavior, alternating conditions, and counter limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->