### PR TITLE
feat(#2309): count heap events and report them on /json/tele

### DIFF
--- a/src/BleFingerprintCollection.cpp
+++ b/src/BleFingerprintCollection.cpp
@@ -1,6 +1,7 @@
 #include "BleFingerprintCollection.h"
 
 #include "defaults.h"
+#include "globals.h"
 #include "mqtt.h"
 #include "Logger.h"
 #include <Arduino.h>
@@ -33,6 +34,10 @@ void removeSlot(size_t index, bool notify = true) {
     slot.fingerprint = nullptr;
     if (activeFingerprints > 0)
         --activeFingerprints;
+    // The single choke point every destruction passes through, by eviction or by
+    // CleanupOldFingerprints(). Pairs with the fpNew bump in getFingerprintInternal(), so
+    // fpNew - fpDel tracks activeFingerprints.
+    fpDel.fetch_add(1, std::memory_order_relaxed);
 
     if (notify && onDel)
         dying.push_back(doomed);
@@ -535,6 +540,11 @@ FingerprintLease getFingerprintInternal(BLEAdvertisedDevice *advertisedDevice) {
         log_e("Failed to allocate fingerprint");
         return {};
     }
+    // Counted here rather than at the onAdd dispatch in Seen(): onAdd only fires when
+    // BleFingerprint::seen() returns true, which it skips for ignored and hidden devices,
+    // and GUI::Added() filters on getIgnore() again. Those devices are still allocated, so
+    // an onAdd-based count would miss exactly the allocations #2309 is trying to attribute.
+    fpNew.fetch_add(1, std::memory_order_relaxed);
 
     if (auto *found = findById(created->getId())) {
         created->setInitial(*found);

--- a/src/HttpWebServer.cpp
+++ b/src/HttpWebServer.cpp
@@ -1,5 +1,7 @@
 #include "HttpWebServer.h"
 
+#include <esp_timer.h>
+
 #include "ArduinoJson.h"
 #include "AsyncJson.h"
 #include "Enrollment.h"
@@ -27,6 +29,11 @@ void serializeInfo(JsonObject &root) {
 // moving with the device count is churn. Working that out took months of graph-swapping
 // on #2309.
 //
+// Now also the leak-hunt event counters. Those three shapes say what kind of problem it is
+// but not whose; regressing freeHeap against fpNew/fpDel/telePubs/mqttRetries over a soak
+// is what names the owner, and polling this endpoint into a CSV is how that data gets
+// collected without a broker in the loop.
+//
 // Deliberately allocation-free, and deliberately not routed through serveJson. That path
 // refuses with 429 when it cannot afford a 12KB document — so hanging these numbers off it
 // would hide them precisely when the node is in the trouble they describe. A fixed stack
@@ -34,13 +41,25 @@ void serializeInfo(JsonObject &root) {
 // no fingerprintMutex acquisition (contending the scan task) and no second walk of the
 // free-block list on every poll.
 void serveTele(AsyncWebServerRequest *request) {
-    char buf[256];
+    // 512, not 256: eleven fields with every counter saturated at ten digits still leave
+    // ~280 characters for the room name, more headroom than the four-field body had in 256.
+    // Still a stack buffer, on the AsyncTCP task's 8KB stack.
+    char buf[512];
+    TeleCounters counters;
+    counters.uptime = esp_timer_get_time() / 1000000;
+    counters.minHeap = ESP.getMinFreeHeap();
+    counters.fpNew = fpNew.load(std::memory_order_relaxed);
+    counters.fpDel = fpDel.load(std::memory_order_relaxed);
+    counters.telePubs = telePubs.load(std::memory_order_relaxed);
+    counters.mqttRetries = mqttRetries.load(std::memory_order_relaxed);
+    counters.allocFails = allocFails.load(std::memory_order_relaxed);
     // Size(false): a GET reports what is there, it does not expire fingerprints as a side
     // effect of being observed.
     size_t const len = buildTeleJson(buf, sizeof(buf), room.c_str(),
                                      ESP.getFreeHeap(),
                                      ESP.getMaxAllocHeap(),
-                                     BleFingerprintCollection::Size(false));
+                                     BleFingerprintCollection::Size(false),
+                                     counters);
     if (len == 0) {
         // Only reachable via an absurdly long room. Refusing beats the alternative: a
         // truncated body under a 200 is indistinguishable from a corrupt response, and

--- a/src/TeleJson.h
+++ b/src/TeleJson.h
@@ -15,19 +15,43 @@
 // `room` is user-set free text (main.cpp: HeadlessWiFiSettings.string("room", ...)), so a
 // quote, backslash or control character in it would break a hand-formatted body.
 // ArduinoJson escapes at serialization time; that is the whole reason not to snprintf this.
+// Leak-hunt event counters (globals.h) plus the two derived heap numbers that go with
+// them. Defaulted at the call site so the endpoint stays usable — and testable — without
+// them. See the #2309 comment in globals.h for why counters rather than heap deltas.
+struct TeleCounters {
+    uint32_t uptime = 0;       // seconds, matching sendTelemetry()'s expression
+    uint32_t minHeap = 0;      // ESP.getMinFreeHeap(): the low-water mark, not the current
+    uint32_t fpNew = 0;
+    uint32_t fpDel = 0;
+    uint32_t telePubs = 0;
+    uint32_t mqttRetries = 0;
+    uint32_t allocFails = 0;
+};
+
 inline size_t buildTeleJson(char *out, size_t size, const char *room,
-                            uint32_t freeHeap, uint32_t maxHeap, uint32_t fingerprints) {
+                            uint32_t freeHeap, uint32_t maxHeap, uint32_t fingerprints,
+                            const TeleCounters &counters = {}) {
     if (out == nullptr || size == 0) return 0;
 
     // Stack, not DynamicJsonDocument: this endpoint has to answer when the heap is too
     // short for /json to reply at all. A const char* is stored by pointer rather than
     // copied, so a long room costs no capacity here — it shows up in the length check
     // below instead, which is what catches it.
-    StaticJsonDocument<JSON_OBJECT_SIZE(4)> doc;
+    StaticJsonDocument<JSON_OBJECT_SIZE(11)> doc;
     doc["room"] = room;
     doc["freeHeap"] = freeHeap;
     doc["maxHeap"] = maxHeap;
     doc["fingerprints"] = fingerprints;
+    // Unconditional, unlike the MQTT telemetry document's omit-when-zero fields: this
+    // endpoint gets polled into a CSV for the leak regression, and a column that
+    // disappears when a counter happens to be zero is worse than a zero.
+    doc["uptime"] = counters.uptime;
+    doc["minHeap"] = counters.minHeap;
+    doc["fpNew"] = counters.fpNew;
+    doc["fpDel"] = counters.fpDel;
+    doc["telePubs"] = counters.telePubs;
+    doc["mqttRetries"] = counters.mqttRetries;
+    doc["allocFails"] = counters.allocFails;
 
     if (doc.overflowed()) return 0;
     if (measureJson(doc) >= size) return 0;  // >= : leave room for the NUL

--- a/src/globals.h
+++ b/src/globals.h
@@ -3,6 +3,7 @@
 #include <AsyncMqttClient.h>
 #include <ESPAsyncWebServer.h>
 #include <ArduinoJson.h>
+#include <atomic>
 #include "Logger.h"
 #include "BleFingerprintCollection.h"
 
@@ -37,6 +38,22 @@ _DECL AsyncWebSocket ws _INIT_N((("/ws")));
 _DECL bool enrolling;
 _DECL String enrolledId;
 _DECL unsigned long enrollingEndMillis;
+
+// Leak-hunt event counters (#2309). Three candidates fit that report's ~22KB/h at ~100
+// bytes per event and its serial log cannot separate them, so count the events instead of
+// guessing: regressing freeHeap against these after a soak names the owner. Sampling free
+// heap around a call site does not work here — BLE and WiFi allocate from the other core
+// mid-measurement — but a monotonic count is noise-free.
+//
+// std::atomic because allocFails is bumped from heapCapsAllocFailedHook, which runs in
+// whatever context the failing allocation did, and fpNew/fpDel are bumped from the scan
+// task while the loop task reads them. Aligned 32-bit RMW is lock-free on both the Xtensa
+// and RISC-V targets here, so this costs nothing on the BLE path.
+_DECL std::atomic<uint32_t> fpNew _INIT(0),        // BleFingerprint allocations
+                            fpDel _INIT(0),        // BleFingerprint destructions
+                            telePubs _INIT(0),     // successful telemetry publishes
+                            mqttRetries _INIT(0),  // pub() retry iterations
+                            allocFails _INIT(0);   // heap_caps allocation failures
 
 // I2C
 _DECL bool I2C_Bus_1_Started;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,10 @@
 
 void heapCapsAllocFailedHook(size_t requestedSize, uint32_t caps, const char *functionName)
 {
+    // The counter, not just the log line: fragmentation onset is the thing #2309 needs to
+    // see, and until now seeing it meant scraping serial off a device that was already
+    // failing. /json/tele and MQTT telemetry both carry this.
+    allocFails.fetch_add(1, std::memory_order_relaxed);
     ESP_EARLY_LOGE("heap", "%s failed to allocate %lu bytes with 0x%lX capabilities", functionName, static_cast<unsigned long>(requestedSize), static_cast<unsigned long>(caps));
 }
 
@@ -141,7 +145,10 @@ bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned in
     doc["loopStack"] = uxTaskGetStackHighWaterMark(nullptr);
     doc["bleStack"] = bleStack;
 
-    if (pub(teleTopic.c_str(), 0, false, doc)) return true;
+    if (pub(teleTopic.c_str(), 0, false, doc)) {
+        telePubs.fetch_add(1, std::memory_order_relaxed);
+        return true;
+    }
 
     teleFails++;
     log_e("Error after 10 tries sending telemetry (%d times since boot)", teleFails);

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -11,6 +11,9 @@ bool pub(const char *topic, uint8_t qos, bool retain, const char *payload, size_
     {
         if (mqttClient.publish(topic, qos, retain, payload, length, dup, message_id))
             return true;
+        // Counted per failed iteration, not per call: #2309 needs the retry rate, and a
+        // publish that succeeds first time contributes nothing to it.
+        mqttRetries.fetch_add(1, std::memory_order_relaxed);
         delay(25);
     }
     return false;

--- a/test/test_native_tele/test_tele_json.cpp
+++ b/test/test_native_tele/test_tele_json.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 
-std::string build(const char* room, size_t size = 256) {
+std::string build(const char* room, size_t size = 512) {
     std::string out(size, '\0');
     size_t const len = buildTeleJson(&out[0], size, room, 84710, 28236, 29);
     if (len == 0) return "";
@@ -29,8 +29,67 @@ void expect_fields(const std::string& body) {
 void test_plain_room(void) {
     std::string const body = build("Dining");
     TEST_ASSERT_EQUAL_STRING(
-        "{\"room\":\"Dining\",\"freeHeap\":84710,\"maxHeap\":28236,\"fingerprints\":29}",
+        "{\"room\":\"Dining\",\"freeHeap\":84710,\"maxHeap\":28236,\"fingerprints\":29,"
+        "\"uptime\":0,\"minHeap\":0,\"fpNew\":0,\"fpDel\":0,\"telePubs\":0,"
+        "\"mqttRetries\":0,\"allocFails\":0}",
         body.c_str());
+}
+
+// Every counter is emitted even at zero (see buildTeleJson): the endpoint is polled into a
+// CSV, and a column that disappears on a zero would silently shift the others.
+void test_counters_are_reported(void) {
+    TeleCounters counters;
+    counters.uptime = 24635;
+    counters.minHeap = 19112;
+    counters.fpNew = 1463;
+    counters.fpDel = 1379;
+    counters.telePubs = 1560;
+    counters.mqttRetries = 3500;
+    counters.allocFails = 3395;
+
+    std::string out(512, '\0');
+    size_t const len =
+        buildTeleJson(&out[0], out.size(), "Dining", 84710, 28236, 29, counters);
+    TEST_ASSERT_TRUE(len > 0);
+    out.resize(len);
+
+    TEST_ASSERT_TRUE(out.find("\"uptime\":24635") != std::string::npos);
+    TEST_ASSERT_TRUE(out.find("\"minHeap\":19112") != std::string::npos);
+    TEST_ASSERT_TRUE(out.find("\"fpNew\":1463") != std::string::npos);
+    TEST_ASSERT_TRUE(out.find("\"fpDel\":1379") != std::string::npos);
+    TEST_ASSERT_TRUE(out.find("\"telePubs\":1560") != std::string::npos);
+    TEST_ASSERT_TRUE(out.find("\"mqttRetries\":3500") != std::string::npos);
+    TEST_ASSERT_TRUE(out.find("\"allocFails\":3395") != std::string::npos);
+    expect_fields(out);
+}
+
+// Ten-digit counters are what the document has to survive at the top of the uint32 range;
+// the buffer sizing in serveTele() is chosen for this case, not for the zeros above.
+void test_saturated_counters_still_fit(void) {
+    TeleCounters counters;
+    counters.uptime = counters.minHeap = counters.fpNew = counters.fpDel =
+        counters.telePubs = counters.mqttRetries = counters.allocFails = 4294967295u;
+
+    std::string out(512, '\0');
+    size_t const len = buildTeleJson(&out[0], out.size(), "Dining", 4294967295u,
+                                     4294967295u, 4294967295u, counters);
+    TEST_ASSERT_TRUE(len > 0);
+    out.resize(len);
+    TEST_ASSERT_TRUE(out.find("\"allocFails\":4294967295") != std::string::npos);
+}
+
+// A room that fit comfortably under the four-field document no longer fits under the
+// eleven-field one. It must still be refused rather than truncated — the widening must not
+// have opened a hole in the rule the rest of this file exists to enforce.
+void test_counters_do_not_break_the_refusal(void) {
+    std::string const room(200, 'x');
+    std::string out(256, '\0');
+    TeleCounters counters;
+    counters.uptime = 24635;
+    TEST_ASSERT_EQUAL_UINT(
+        0, buildTeleJson(&out[0], out.size(), room.c_str(), 84710, 28236, 29, counters));
+    // Nothing was written: the buffer is untouched, not half-filled.
+    TEST_ASSERT_TRUE(out.find_first_not_of('\0') == std::string::npos);
 }
 
 void test_quote_is_escaped(void) {
@@ -105,6 +164,9 @@ void test_degenerate_buffers(void) {
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_plain_room);
+    RUN_TEST(test_counters_are_reported);
+    RUN_TEST(test_saturated_counters_still_fit);
+    RUN_TEST(test_counters_do_not_break_the_refusal);
     RUN_TEST(test_quote_is_escaped);
     RUN_TEST(test_backslash_is_escaped);
     RUN_TEST(test_control_characters_are_escaped);


### PR DESCRIPTION
Second of three PRs off #2309. Independent of #2453 (the watchdog); PR 3 stacks on this one.

## Why

Five fixes have landed (#2431, #2435, #2439, #2445, #2446) and S3 nodes still lose **~22 KB/h with the fingerprint count flat**. The garbage-`std::string` theory is dead: build `5840269` existed purely to print `[CORRUPT]` when `getName`/`getServiceData`/`getManufacturerData` returned `size > 512`, and it ran the entire 6.8 h decline into the crash with **zero hits**.

Three candidates fit that rate at ~100 B/event and the serial log cannot separate them:

| suspect | events in 6.5 h | B/event needed |
|---|---|---|
| fingerprint New/Del cycle (1463 New / 1379 Del, count flat) | ~1380 | ~103 |
| telemetry publish, 15 s cadence | ~1560 | ~91 |
| failed-publish retry path (10× `delay(25)`) | ~350 fails | bursty |

The lifecycle code reads clean on inspection — `BleFingerprint` holds only `String`s and `unique_ptr`s, and `dying` is drained by every `FingerprintLock` destructor. So the leak is either subtler than a missing `delete` or it is not in that path at all. **Stop guessing and measure.**

Counters, not byte-deltas: sampling free heap around a call site is noise on this chip because BLE and WiFi allocate from the other core mid-measurement, but a monotonic event count is noise-free, and regressing `freeHeap` against these after a soak names the owner.

## The counters

| counter | bumped at |
|---|---|
| `fpNew` | every `BleFingerprint` allocation |
| `fpDel` | every `BleFingerprint` destruction |
| `telePubs` | every successful telemetry publish |
| `mqttRetries` | every `pub()` retry iteration |
| `allocFails` | every `heap_caps` allocation failure |

Two placement decisions worth reviewing:

- **`fpNew` is counted at the `new` in `getFingerprintInternal()`, not at the `onAdd` dispatch.** `onAdd` only fires when `BleFingerprint::seen()` returns true, which it skips for `ignore || hidden`, and `GUI::Added()` filters on `getIgnore()` again. Ignored devices are still heap-allocated, so an `onAdd`-based count would miss exactly the allocations we are trying to attribute.
- **`fpDel` is counted in `removeSlot()`**, the single point every destruction passes through — by eviction or by `CleanupOldFingerprints()` — so `fpNew - fpDel` tracks `activeFingerprints`.

`allocFails` is what makes fragmentation onset visible without scraping serial off a device that is already failing.

`std::atomic<uint32_t>` because `allocFails` is bumped from `heapCapsAllocFailedHook` in whatever context the failing allocation ran, and `fpNew`/`fpDel` are bumped from the scan task while the loop task reads them. Aligned 32-bit RMW is lock-free on both Xtensa (S32C1I) and the RISC-V targets, so the BLE path pays nothing.

## Exposure

They ride out on `/json/tele` (added by #2430), which already answers from a fixed stack buffer when `/json` is too expensive to serve — deliberately, so it still works when the node is in the trouble these numbers describe. Added alongside `uptime` and `ESP.getMinFreeHeap()`.

Emitted **unconditionally**, unlike the MQTT document's omit-when-zero fields: this endpoint gets polled into a CSV for the regression, and a column that vanishes on a zero would shift the others.

`buf[256]` → `buf[512]`. Measured: with every counter saturated at ten digits, that still leaves ~280 characters for the room name — more headroom than the four-field body had in 256. The `overflowed()` / `measureJson() >= size` refuse-rather-than-truncate semantics are unchanged.

## Verification

- `test/test_native_tele/` — updated for the widened document, plus three new cases: all seven counters reported with the values passed in; a fully saturated document still fits; and a room that fit under the four-field document is now **refused** rather than truncated, with the buffer left untouched. All passing.
- **Note on how those were run:** PlatformIO is not available in this environment, so the tests were compiled and run with `g++ -std=gnu++17 -Wall -Wextra` against ArduinoJson v6.21.5 and a minimal Unity shim rather than via `pio test -e native`. Please confirm under real `pio test -e native`. Firmware builds were **not** run here — CI covers them.
- **HIL, PR event:** `hil_monitor.py` already polls `/json/tele`, so a malformed or over-long body fails the run.
- **Out-of-repo follow-up:** `hil_monitor.py` lives in `ESPresense/firmware-tester`, not here. Extra JSON keys are additive and will not break its parser, but it needs teaching to *record* them for the KB/h regression. Does not block this PR.

## What this is for

Once this and PR 3 are on main, the existing nightly 8 h HIL cron produces the series. The counters are all roughly linear in uptime, so a naive multiple regression is ill-conditioned — the experiment is to vary one rate at a time on the same build, using settings that already exist:

- **`publishTele` off for one run, on for the next.** Unchanged KB/h with telemetry off exonerates both the telemetry and the retry candidates in one step.
- **Halve `forgetMs`** to roughly double the New/Del rate. If KB/h follows, the fingerprint lifecycle owns it.

Whichever knob moves KB/h is the leak.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJShR6eN7MCm2tGDUwLdKt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded telemetry data with uptime, memory, fingerprint, publication, retry, and allocation-failure metrics.
  * Added visibility into fingerprint creation and deletion activity.
* **Bug Fixes**
  * Improved tracking of failed allocations and MQTT retry attempts.
  * Prevented incomplete telemetry output when the response buffer is too small.
* **Tests**
  * Added coverage for populated counters, maximum counter values, and oversized telemetry responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->