### PR TITLE
feat(#2309): carry the heap event counters on MQTT telemetry too

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,10 +140,24 @@ bool sendTelemetry(unsigned int totalSeen, unsigned int totalFpSeen, unsigned in
     auto freeHeap = ESP.getFreeHeap();
     doc["freeHeap"] = freeHeap;
     doc["maxHeap"] = maxHeap;
+    doc["minHeap"] = ESP.getMinFreeHeap();
     doc["fingerprints"] = fingerprintCount;
     doc["scanStack"] = uxTaskGetStackHighWaterMark(scanTaskHandle);
     doc["loopStack"] = uxTaskGetStackHighWaterMark(nullptr);
     doc["bleStack"] = bleStack;
+    // The same leak-hunt counters /json/tele carries, so the two agree and the soak data
+    // can come from whichever the reporter already has. Most of #2309's graphs are built
+    // from this payload, not from curl.
+    doc["fpNew"] = fpNew.load(std::memory_order_relaxed);
+    doc["fpDel"] = fpDel.load(std::memory_order_relaxed);
+    doc["telePubs"] = telePubs.load(std::memory_order_relaxed);
+    doc["mqttRetries"] = mqttRetries.load(std::memory_order_relaxed);
+    doc["allocFails"] = allocFails.load(std::memory_order_relaxed);
+
+    // This document has never been checked for overflow, and it is now within a few fields
+    // of its capacity. A silently truncated telemetry payload is exactly the kind of
+    // "success that lies" that cost #2309 months, so say so.
+    if (doc.overflowed()) log_e("Telemetry document overflowed; fields were dropped");
 
     if (pub(teleTopic.c_str(), 0, false, doc)) {
         telePubs.fetch_add(1, std::memory_order_relaxed);


### PR DESCRIPTION
Third of three PRs off #2309. **Stacked on #2454** — review that one first; this diff is 14 lines on top of it.

## Why

#2454 puts `fpNew`, `fpDel`, `telePubs`, `mqttRetries` and `allocFails` on `/json/tele`, but most of the graphs attached to #2309 are built from the MQTT telemetry payload, not from curl. Report the same five there, reading the same globals so the two agree and the soak data can come from whichever source a reporter already has. `minHeap` joins the `freeHeap`/`maxHeap` pair already published.

## The overflow check

The shared telemetry document has **never** been checked for overflow, and it is now closer to its 768-byte capacity than it was. Rather than reflexively bumping the capacity, I measured it.

| build | counters | `memoryUsage()` | overflowed |
|---|---|---|---|
| 64-bit host | no | 672 / 768 | no |
| 64-bit host | yes | 768 / 768 | **yes** |
| 64-bit host, cap 1024 | yes | 832 | no |

That overflow is a pointer-size artifact. `VariantSlot` is ~28 bytes on a 64-bit host but 16 on a 32-bit target, so the same ~26-member document lands near 500 bytes on an ESP32 with room to spare. **The capacity is therefore left alone** — spending 256 bytes of permanent heap on a node under investigation for losing heap is the wrong trade when the measurement says it is not needed.

`if (doc.overflowed()) log_e(...)` is what makes that conclusion self-verifying. If the reasoning above is wrong, the device says so on serial instead of silently publishing a truncated payload — which is precisely the "success that lies" failure mode that cost this issue months.

No new Home Assistant discovery entities: these ride as attributes on the existing `json_attr_t` connectivity sensor. Five diagnostic entities would be scope creep.

## Verification

- **HIL, PR event:** green, **and no `Telemetry document overflowed` in the captured serial log.** That line appearing is the signal to bump `doc` to 1024; its absence across a run that populates every optional field is the confirmation that 768 is enough on real hardware.
- Firmware builds were not run in this environment (no PlatformIO available) — CI covers them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJShR6eN7MCm2tGDUwLdKt)_