### PR TITLE
ci(hil): 4h soak on main, and let a PR ask for one

### DIFF
--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -13,6 +13,42 @@ labels:
   backend: docker
   platform: linux/amd64
 
+variables:
+  # One command block for all four devices. Everything device-specific comes from the
+  # step's own DEVICE / FIRMWARE_ENV, including the lock file name, so the soak policy
+  # below lives in exactly one place instead of four copies drifting apart.
+  - &hil_run |
+    export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
+    git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+    flock -w 18000 /lock/$FIRMWARE_ENV.lock bash -c '
+      set -e
+
+      # Soak length. Anything that is not an ordinary PR gets the full run: main, the
+      # nightly cron, and PRs that opt in.
+      #
+      # 4h, not 8h. #2309 declines at ~22KB/h from ~160KB, so a leak of that size is
+      # unambiguous by 4h, and halving the run doubles how many soaks the single bench
+      # can serve — which is the actual constraint now that PRs can request one.
+      #
+      # Two ways for a PR to ask for a soak, because you do not always know a change is
+      # memory-related when you name the branch:
+      #   * push it as soak/<whatever>
+      #   * put [soak] anywhere in the head commit message (an empty commit works, and
+      #     unlike renaming a branch it does not close the PR)
+      SOAK_SECS=14400
+      DURATION_SECS=$SOAK_SECS
+      if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
+        DURATION_SECS=180
+        case "$CI_COMMIT_SOURCE_BRANCH" in soak/*) DURATION_SECS=$SOAK_SECS ;; esac
+        case "$CI_COMMIT_MESSAGE" in *"[soak]"*) DURATION_SECS=$SOAK_SECS ;; esac
+      fi
+      echo "HIL $FIRMWARE_ENV: ${DURATION_SECS}s (event=$CI_PIPELINE_EVENT branch=$CI_COMMIT_SOURCE_BRANCH)"
+
+      PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
+      python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
+      python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
+    '
+
 steps:
   - name: ble-flood
     image: ghcr.io/espresense/ble-loadgen:1
@@ -45,22 +81,7 @@ steps:
       PLATFORMIO_BUILD_CACHE_DIR: /cache/platformio-esp32/build_cache
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32/platforms
     commands:
-      - |
-        export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
-        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/esp32.lock bash -c '
-          set -e
-          if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
-            DURATION_SECS=180
-          elif [ "$CI_PIPELINE_EVENT" = "cron" ]; then
-            DURATION_SECS=28800
-          else
-            DURATION_SECS=28800
-          fi
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
-          python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
-          python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
-        '
+      - *hil_run
 
   - name: test-esp32c3
     image: ghcr.io/espresense/firmware-tester:1
@@ -85,22 +106,7 @@ steps:
       PLATFORMIO_BUILD_CACHE_DIR: /cache/platformio-esp32c3/build_cache
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32c3/platforms
     commands:
-      - |
-        export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
-        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/esp32c3.lock bash -c '
-          set -e
-          if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
-            DURATION_SECS=180
-          elif [ "$CI_PIPELINE_EVENT" = "cron" ]; then
-            DURATION_SECS=28800
-          else
-            DURATION_SECS=28800
-          fi
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
-          python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
-          python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
-        '
+      - *hil_run
 
   - name: test-esp32c6
     image: ghcr.io/espresense/firmware-tester:1
@@ -125,22 +131,7 @@ steps:
       PLATFORMIO_BUILD_CACHE_DIR: /cache/platformio-esp32c6/build_cache
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32c6/platforms
     commands:
-      - |
-        export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
-        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/esp32c6.lock bash -c '
-          set -e
-          if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
-            DURATION_SECS=180
-          elif [ "$CI_PIPELINE_EVENT" = "cron" ]; then
-            DURATION_SECS=28800
-          else
-            DURATION_SECS=28800
-          fi
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
-          python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
-          python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
-        '
+      - *hil_run
 
   - name: test-esp32s3
     image: ghcr.io/espresense/firmware-tester:1
@@ -165,19 +156,4 @@ steps:
       PLATFORMIO_BUILD_CACHE_DIR: /cache/platformio-esp32s3/build_cache
       PLATFORMIO_PLATFORMS_DIR: /cache/platformio-esp32s3/platforms
     commands:
-      - |
-        export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
-        git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-        flock -w 3600 /lock/esp32s3.lock bash -c '
-          set -e
-          if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
-            DURATION_SECS=180
-          elif [ "$CI_PIPELINE_EVENT" = "cron" ]; then
-            DURATION_SECS=28800
-          else
-            DURATION_SECS=28800
-          fi
-          PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
-          python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"
-          python3 /scripts/hil_monitor.py --port $DEVICE --duration $DURATION_SECS
-        '
+      - *hil_run

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -19,7 +19,12 @@ variables:
   # below lives in exactly one place instead of four copies drifting apart.
   - &hil_run |
     export PLATFORMIO_BUILD_DIR="$PWD/.pio/build-$FIRMWARE_ENV"
-    git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+    # Bare $GITHUB_TOKEN, not the braced form: Woodpecker substitutes braced references in
+    # the YAML before the container ever sees it, and secrets are not available at that
+    # point. Braces fail quietly here — an emptied token still clones the public lib_deps,
+    # just anonymously and against the unauthenticated rate limit. Escape as $${...} when
+    # the shell genuinely needs braces, as the duration log line below does.
+    git config --global url."https://$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/"
     flock -w 18000 /lock/$FIRMWARE_ENV.lock bash -c '
       set -e
 
@@ -42,7 +47,9 @@ variables:
         case "$CI_COMMIT_SOURCE_BRANCH" in soak/*) DURATION_SECS=$SOAK_SECS ;; esac
         case "$CI_COMMIT_MESSAGE" in *"[soak]"*) DURATION_SECS=$SOAK_SECS ;; esac
       fi
-      echo "HIL $FIRMWARE_ENV: ${DURATION_SECS}s (event=$CI_PIPELINE_EVENT branch=$CI_COMMIT_SOURCE_BRANCH)"
+      # $${...} escapes the brace form past Woodpecker so the shell expands it after the
+      # assignments above. Braces are needed to keep the "s" out of the variable name.
+      echo "HIL $FIRMWARE_ENV: $${DURATION_SECS}s (event=$CI_PIPELINE_EVENT branch=$CI_COMMIT_SOURCE_BRANCH)"
 
       PLATFORMIO_UPLOAD_PORT=$DEVICE pio run -e $FIRMWARE_ENV -t erase -t upload
       python3 /scripts/improv_wifi.py --port $DEVICE --ssid "$WIFI_SSID" --password "$WIFI_PASSWORD"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,7 @@
 
 * After modifying files under `ui`, execute `npm run build` in that folder to regenerate C++ headers under `src`.
 * `pio-on && pio` to run platform io
+* HIL (`.woodpecker/hil.yml`) runs 180s per device on a PR and 4h on main and the nightly
+  cron. A memory or stability change needs the long run to prove anything, so ask for one:
+  push the branch as `soak/<name>`, or put `[soak]` anywhere in the head commit message
+  (an empty commit works, and unlike renaming a branch it will not close the PR).


### PR DESCRIPTION
Prerequisite for the #2309 PRs (#2453, #2454, #2455): none of them can prove anything in a 180 s HIL run, and today the only way to get a long one is to merge and wait for the cron.

## Duration policy

| pipeline | before | after |
|---|---|---|
| `pull_request` | 180 s | 180 s |
| `pull_request` opting in | — | **4 h** |
| `push` → main | 8 h | **4 h** |
| `cron` | 8 h | **4 h** |

8 h → 4 h because #2309 declines at ~22 KB/h from ~160 KB — a leak that size is unambiguous well before 4 h — and halving the run doubles how many soaks the single bench can serve. That capacity is the binding constraint once PRs can request one.

## How a PR asks for a soak

Either works:

- push the branch as **`soak/<whatever>`**
- put **`[soak]`** anywhere in the head commit message

Two mechanisms because you don't always know a change is memory-related when you name the branch. Renaming a branch closes the PR on GitHub; an empty `git commit --allow-empty -m "[soak]"` doesn't, so the marker is the mid-review escape hatch.

## Why not PR labels

Labels would read better, and Woodpecker does expose `CI_COMMIT_PULL_REQUEST_LABELS` — but only on 3.x servers. On an older one it evaluates to empty, the `case` never matches, and the soak silently never runs while the PR goes green in three minutes. **A gate that fails silently is worse than one that's slightly clumsy to set**, so this matches on `CI_COMMIT_SOURCE_BRANCH` and `CI_COMMIT_MESSAGE`, which every version injects. Happy to switch to labels if you can confirm the server is ≥3.x.

Git tags don't work at all here — they're commit-level and don't fire on PR pipelines.

## Two things that came along

- **The four device steps had four byte-identical copies of the command block**, so the duration policy would have had to be written four times and drift. They collapse to one YAML anchor. The lock file name now derives from `FIRMWARE_ENV`, which already matched the four lock names exactly (verified below). No other step key changes.
- **`flock -w` 3600 → 18000.** A 4 h soak holds the device lock for 4 h; any other pipeline queued behind it would otherwise give up after an hour and fail for no reason of its own.

## Verification

Parsed both versions and diffed them structurally — every step key except `commands` is byte-identical, `when` and `labels` unchanged, and each step's derived lock path matches the one it replaced:

```
test-esp32       old lock=esp32.lock     FIRMWARE_ENV=esp32    -> /lock/esp32.lock    OK
test-esp32c3     old lock=esp32c3.lock   FIRMWARE_ENV=esp32c3  -> /lock/esp32c3.lock  OK
test-esp32c6     old lock=esp32c6.lock   FIRMWARE_ENV=esp32c6  -> /lock/esp32c6.lock  OK
test-esp32s3     old lock=esp32s3.lock   FIRMWARE_ENV=esp32s3  -> /lock/esp32s3.lock  OK

distinct command blocks across 4 device steps: 1 (was 4)
```

Then extracted the duration logic from the parsed YAML and ran it under the same `bash -c '...'` nesting the file uses:

```
event=cron         branch=                          -> 14400s
event=push         branch=main                      -> 14400s
event=pull_request branch=claude/2309-tele-counters ->   180s
event=pull_request branch=soak/2309-counters        -> 14400s
event=pull_request msg="chore: opt in [soak]"       -> 14400s
event=pull_request branch=soaked-not-a-prefix       ->   180s   (glob needs the slash)
event=pull_request branch=feature/soak/nested       ->   180s   (must be a prefix)
```

Also confirmed a commit message containing a single quote and `$(...)` can't break out — the variable is expanded by the inner shell at runtime, never spliced into the script text.

## One thing I could not check

Woodpecker's per-pipeline timeout is a server-side repo setting I can't read from here. It must already be ≥ 8 h for the current cron to work, so 4 h is strictly safer — but PR pipelines now run up to 4 h too, and they share that same limit. Worth a glance at the repo settings before merging.

## After this merges

#2453, #2454 and #2455 need `main` merged in to pick up this config (PR pipelines use the config on the PR head), then an empty `[soak]` commit each to get their 4 h runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJShR6eN7MCm2tGDUwLdKt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized hardware-in-the-loop testing across supported devices.
  * Pull request tests now run for 180 seconds by default.
  * Main and nightly runs use a four-hour soak duration.
  * Extended soak testing can be requested through branch naming or commit messages.
  * Improved device locking, firmware upload, Wi-Fi provisioning, and monitoring setup.
* **Documentation**
  * Added guidance for requesting extended hardware stability tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->