### PR TITLE
fix(#2309): skip updater under low heap

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -683,7 +683,7 @@ void loop() {
         // for twenty minutes without the one number that explained the crash — its largest
         // free block was already under the 2312 byte request that kept failing.
         if (freeHeap < 20000) Log.printf("Low memory: %lu bytes free, largest block %lu\r\n", static_cast<unsigned long>(freeHeap), static_cast<unsigned long>(maxAlloc));
-        if (freeHeap > 40000) Updater::Loop();
+        if (freeHeap > 70000) Updater::Loop();
 
         // ponytail: watchdog, not a leak fix. A heap-starved node limps forever (mqtt and
         // telemetry both fail, nothing recovers), so reboot after 60s stuck below the


### PR DESCRIPTION
## Summary

- raise the slow-loop updater guard from 40 KB free heap to 70 KB
- keep ArduinoOTA/update work out of the low-heap range seen in the Aug 3 S3 serial log
- align the implementation with the existing comment that updater work should wait for >70 KB free heap

## Why

The issue #2309 log for the S3 shows repeated internal heap allocation failures, then a Core 1 double exception while reconnecting Wi-Fi. Decoding the stack against the current S3 ELF points through `MD5Builder::addStream`, `SerialImprov::handleImprovPacket`, and `Updater::Loop()` from `main.cpp:682`. This does not claim to fix the underlying S3 heap slope, but it removes one avoidable crash path when the node is already heap-starved.

## Validation

- `pio test -e native -f test_native_tele`
- `pio run -e esp32s3`

## HIL follow-up

Requested next validation: run the repository HIL workflow against this branch and compare S3 behavior around low-memory reconnect/update handling.