### PR TITLE
tune(ble): drop classic ESP32 max fingerprints 60 -> 45

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -74,7 +74,7 @@
 #elif defined(ESP32C3) || defined(ESP32C6)
 #define DEFAULT_MAX_FINGERPRINTS 200
 #else
-#define DEFAULT_MAX_FINGERPRINTS 60
+#define DEFAULT_MAX_FINGERPRINTS 45
 #endif
 
 // RX_ADJ_RSSI Defaults


### PR DESCRIPTION
Classic ESP32 is still running out of heap under BLE flood with the fingerprint pool at cap.

### Evidence

Third recurrence of the same crash. HIL pipelines 1097 (#2457) and 1099 (#2459) both aborted with an identical signature:

```
abort() was called at PC 0x401a6c7a on core 1
FAIL: Crash pattern detected: 'abort()'
```

Same PC, same backtrace frames in both runs, preceded by repeated `sendTelemetry()` failures — the `bad_alloc`-from-`std::string` path that #2445 already documented when it cut 75 → 60.

Neither of those PRs touches firmware (both are UI devDependency bumps), so this is pre-existing on `main`. `main`'s own push pipelines are red too (1095, 1075), with `heap_caps_malloc failed` hooks firing.

### Change

`DEFAULT_MAX_FINGERPRINTS` 60 → 45 for classic ESP32 only. C3/C6 stay at 200, S3 stays at 150 — neither shows this signature.

Going to 45 rather than a smaller step because 100 → 75 → 60 hasn't broken the cycle. Still runtime-configurable via the `max_fingerprints` setting (range 16–2048), so anyone tracking more devices on a classic ESP32 can raise it at their own risk.

Builds clean for `esp32` (RAM 17.6%, flash 66.9%). Needs a HIL soak to confirm the abort is actually gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dWkvvM8jR7TmtvfwcBWu4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the default maximum number of stored fingerprints to 45 on supported non-ESP32S3, non-ESP32C3, and non-ESP32C6 platforms.
  * Platform-specific defaults for ESP32S3, ESP32C3, and ESP32C6 remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->