### PR TITLE
fix(#2309): defer auto-update check on low heap (TLS ~80KB spike)

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -5,6 +5,14 @@
 #define CHECK_FOR_UPDATES_INTERVAL 900000
 #endif
 
+// Minimum free heap before an auto-update check will attempt its TLS handshake. GitHub over
+// WiFiClientSecure transiently needs ~80KB (mbedTLS 16KB in/out record buffers); on a loaded node
+// that spike OOMs (#2309). Below this, the check is deferred to the next interval. A healthy S3
+// reports ~100KB free post-boot, so an unloaded node still updates.
+#ifndef UPDATE_MIN_FREE_HEAP
+#define UPDATE_MIN_FREE_HEAP 90000
+#endif
+
 // Number of seconds to wait for a Station Wifi connection to be established
 #ifndef DEFAULT_WIFI_TIMEOUT
 #define DEFAULT_WIFI_TIMEOUT 60

--- a/src/Updater.cpp
+++ b/src/Updater.cpp
@@ -54,6 +54,18 @@ String getVersionMarker() {
  * calls will not trigger additional update actions.
  */
 void checkForUpdates() {
+    // A WiFiClientSecure TLS handshake to GitHub transiently needs ~80KB (mbedTLS's 16KB in/out
+    // record buffers + the HTTPS response), measured on an S3 (free 91KB -> minfree 12KB per check).
+    // On a memory-tight node (many fingerprints) that spike drives free heap to near-zero — the
+    // "failed to allocate 2312 bytes" storm and dropped telemetry the reporter sees with auto_update
+    // on (#2309). It is NOT a leak (heap fully recovers between checks); it's a periodic spike a
+    // loaded node can't absorb. Defer until there's headroom rather than risk OOM — retries next
+    // interval, and a node with room (e.g. right after boot) still updates.
+    uint32_t freeHeap = ESP.getFreeHeap();
+    if (freeHeap < UPDATE_MIN_FREE_HEAP) {
+        log_w("Deferring update check: %u free < %u needed for the TLS handshake", freeHeap, (unsigned)UPDATE_MIN_FREE_HEAP);
+        return;
+    }
     auto versionMarker = getVersionMarker();
     if (versionMarker.length() > 0) {
         static bool foundNewVersion = false;


### PR DESCRIPTION
## Root cause (not a leak)
The reporter's #2309 "runs out of memory, fingerprints constant, worse with auto_update on" is a **periodic heap spike**, not a leak. Instrumented on an S3 (accelerated update check + heap logging):

- A `WiFiClientSecure` HTTPS HEAD to GitHub transiently needs **~80 KB** (mbedTLS 16 KB in/out record buffers + the response): free **91 KB → minfree 12 KB** per check.
- Heap **fully recovers** between checks — flat across 19 consecutive checks. No cumulative leak.
- On a **loaded** node the spike drives free to near-zero → `failed to allocate 2312 bytes` storm + dropped telemetry. It **crashed an S3 at 200 fingerprints after 2 checks**, but ran clean with headroom (cap 20).
- This is exactly why `auto_update off` (the reporter's non-affected config) avoids it.

## Fix
Gate `checkForUpdates()` on `UPDATE_MIN_FREE_HEAP` (90 KB, tunable via `-D`): a memory-tight node defers the check to the next interval rather than OOMing; a node with room (e.g. just after boot) still updates.

## Follow-up
Shrink `MBEDTLS_SSL_IN/OUT_CONTENT_LEN` (16 KB → 4 KB, sdkconfig) so fuller nodes can also check safely.

Per merge policy: needs real-hardware confirmation (ideally: reporter runs it with auto_update on and confirms the alloc-fail storm stops).

Refs #2309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device stability by deferring automatic update checks when available memory is too low to safely initiate a secure connection.
  * Update checks continue normally when sufficient memory is available.

* **Configuration**
  * Added a configurable minimum free-memory threshold for automatic update checks, set to 90,000 bytes by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->