### PR TITLE
ci: skip UI build output PRs on dependabot branches

### DIFF
--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -47,6 +47,7 @@ jobs:
     - name: Close stale UI build PRs
       if: |
         steps.check_changes.outputs.changes > '0' &&
+        !startsWith(github.head_ref, 'dependabot/') &&
         (github.event_name == 'push' ||
          github.event.pull_request.head.repo.full_name == github.repository)
       uses: actions/github-script@v9
@@ -100,6 +101,7 @@ jobs:
     - name: Create Pull Request
       if: |
         steps.check_changes.outputs.changes > '0' &&
+        !startsWith(github.head_ref, 'dependabot/') &&
         (github.event_name == 'push' ||
          github.event.pull_request.head.repo.full_name == github.repository)
       uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
Dependabot bumps under `ui/` trigger the UI Build workflow, which then opens an "Update UI build outputs" PR targeting the dependabot branch. Noise.

- Adds `!startsWith(github.head_ref, 'dependabot/')` to the stale-PR-close and create-PR steps.
- The UI build itself still runs on dependabot PRs, so the bump is still validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018T5aDwcrRngDLydjWtz7pd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated pull request maintenance now excludes Dependabot branches from stale-pull-request cleanup.
  * UI build pull requests are no longer created for Dependabot branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->