### PR TITLE
ci(dependabot): group updates so each ecosystem opens one PR per run

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,24 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]
 
-  # Maintain dependencies for npm
+  # Maintain dependencies for npm — all ui bumps land as one weekly PR
   - package-ecosystem: "npm"
     directory: "ui/"
     schedule:
       interval: "weekly"
+    groups:
+      ui:
+        patterns: ["*"]
 
   # Maintain dependencies for nuget
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      nuget:
+        patterns: ["*"]


### PR DESCRIPTION
The five separate ui bump PRs (#2473-#2477) in one week were noise. Groups npm ui deps (prod+dev) into a single weekly PR, and batches github-actions and nuget updates the same way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency updates are now grouped by ecosystem—GitHub Actions, npm, and NuGet—and submitted weekly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->