### PR TITLE
fix(mqtt): bump async-mqtt-client to v0.9.4 to stop OOM reboots

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -66,7 +66,7 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer@3.9.3
   https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.5
   https://github.com/ESPresense/NimBLE-Arduino.git#1.4.0
-  https://github.com/ESPresense/async-mqtt-client.git#v0.9.3
+  https://github.com/ESPresense/async-mqtt-client.git#v0.9.4
   bblanchon/ArduinoJson@^6.21.5
   kitesurfer1404/WS2812FX@^1.4.2
 board_build.partitions = partitions_singleapp.csv
@@ -119,7 +119,7 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer@3.9.3
   https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.4
   h2zero/NimBLE-Arduino@^2.3.7
-  https://github.com/ESPresense/async-mqtt-client.git#v0.9.3
+  https://github.com/ESPresense/async-mqtt-client.git#v0.9.4
   bblanchon/ArduinoJson@^6.21.5
   kitesurfer1404/WS2812FX@^1.4.2
 build_flags =
@@ -153,7 +153,7 @@ lib_deps =
   ESP32Async/ESPAsyncWebServer@3.9.3
   https://github.com/ESPresense/HeadlessWiFiSettings.git#v1.1.5
   h2zero/NimBLE-Arduino@^2.3.7
-  https://github.com/ESPresense/async-mqtt-client.git#v0.9.3
+  https://github.com/ESPresense/async-mqtt-client.git#v0.9.4
   bblanchon/ArduinoJson@^6.21.5
   kitesurfer1404/WS2812FX@^1.4.2
 build_flags =


### PR DESCRIPTION
Bumps the three `async-mqtt-client` pins from `v0.9.3` to `v0.9.4`, which carries ESPresense/async-mqtt-client#3.

## Why

`PublishOutPacket` built its bytes in a `std::vector`, so `publish()` allocated through the throwing path. We build with `-fno-exceptions` (`platformio.ini` sets it and unsets `-fexceptions`), where a failed allocation is not a failed publish — it is `std::__throw_bad_alloc()` → `std::terminate` → `abort()` → reboot.

This is the top HIL failure on `main`. CrowCI 1232 (nightly on `main`) and 1233 abort at the identical PC `0x401a6c6a`; `addr2line` against a local rebuild of a6f1105:

```
abort()
 __throw_bad_alloc  (via _Unwind_Resume_or_Rethrow)
 std::_Vector_base<uint8_t>::_M_allocate
 std::vector<uint8_t>::reserve
 AsyncMqttClient::publish()
 pub(const char*, ..., const char*, size_t, ...)
 pub(const char*, ..., JsonVariantConst, ...)
 reportLoop() -> loop() -> loopTask()
```

Under the HIL BLE flood (~420 unique advertisers in 20 s at −32 dBm) the classic ESP32 reboots roughly 20 s after boot — NTP logs `21:25:00` pre-crash and `21:25:20` after the reboot. `publish()`'s existing `getMaxAllocHeap` guard is TOCTOU: the NimBLE task on the other core takes the block between the check and the allocation.

v0.9.4 holds the payload in a `unique_ptr<uint8_t[]>` allocated with `new (std::nothrow)` and drops the message instead of aborting.

## Verification

- `esp32` and `esp32s3` build clean against the new pin; the tag resolves and PlatformIO re-fetches it.
- `std::vector<unsigned char>` no longer appears anywhere in the linked ESP32 firmware — the crash site is gone from the binary, not merely guarded.
- `esp32c3`/`esp32c6` not built locally (the RISC-V toolchain here is an x86 binary that won't run on arm64); CI covers them.

Marked `[soak]` so this gets the 4 h run rather than the 180 s smoke. The failures were intermittent — a smoke that passes once doesn't distinguish fixed from lucky — and the C3's separate symptom (`Too many reconnect attempts; Restarting` at ~19 KB free, fingerprints pegged at 200) only shows over hours.

Per the merge policy this still wants a real-hardware confirmation beyond CI.

## What this does not fix

The ESP32-S3 abort is a different site — same class, but in the NimBLE scan callback (`MyScanCallbacks::onResult` → `Seen()`), logged right after `heap_caps_malloc failed to allocate 504 bytes with 0x1800`. That stays open under #2309.

Refs #2309.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MQTT client library to version 0.9.4 for supported ESP32 platforms.
  * Includes the latest dependency updates and improvements from the newer library version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->