### PR TITLE
ci(hil): 1h on pushes to main, 4h on cron, 3m on PRs

### DIFF
--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -28,8 +28,15 @@ variables:
     flock -w 18000 /lock/$FIRMWARE_ENV.lock bash -c '
       set -e
 
-      # Soak length. Anything that is not an ordinary PR gets the full run: main, the
-      # nightly cron, and PRs that opt in.
+      # Soak length. Only the nightly cron gets the full run by default; pushes and
+      # ordinary PRs get the smoke. A PR opts in either way below; a push only via
+      # [soak] in the message, since CI_COMMIT_SOURCE_BRANCH is a PR-only variable.
+      #
+      # A push to main used to soak too, so a UI-only dependabot push held all four
+      # device locks for 4h. With flock -w 18000 on top, pipelines stacked up past the
+      # repo's 600m timeout: 1213/1216/1219/1223/1237 all died as "Canceled" with
+      # nothing to say about the firmware, and the containers they orphaned failed the
+      # next runs with "container name already in use" (1210, 1211).
       #
       # 4h, not 8h. #2309 declines at ~22KB/h from ~160KB, so a leak of that size is
       # unambiguous by 4h, and halving the run doubles how many soaks the single bench
@@ -42,7 +49,7 @@ variables:
       #     unlike renaming a branch it does not close the PR)
       SOAK_SECS=14400
       DURATION_SECS=$SOAK_SECS
-      if [ "$CI_PIPELINE_EVENT" = "pull_request" ]; then
+      if [ "$CI_PIPELINE_EVENT" != "cron" ]; then
         DURATION_SECS=180
         case "$CI_COMMIT_SOURCE_BRANCH" in soak/*) DURATION_SECS=$SOAK_SECS ;; esac
         case "$CI_COMMIT_MESSAGE" in *"[soak]"*) DURATION_SECS=$SOAK_SECS ;; esac

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -25,6 +25,9 @@ variables:
     # just anonymously and against the unauthenticated rate limit. Escape as $${...} when
     # the shell genuinely needs braces, as the duration log line below does.
     git config --global url."https://$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/"
+    # Everything below runs inside single quotes, so it must contain no apostrophe at
+    # all — not even in a comment. One contraction ends the string and the step dies
+    # with "Syntax error: Unterminated quoted string" *after* the test has passed.
     flock -w 18000 /lock/$FIRMWARE_ENV.lock bash -c '
       set -e
 
@@ -34,7 +37,7 @@ variables:
       #
       # A push to main used to soak too, so a UI-only dependabot push held all four
       # device locks for 4h. With flock -w 18000 on top, pipelines stacked up past the
-      # repo's 600m timeout: 1213/1216/1219/1223/1237 all died as "Canceled" with
+      # 600m repo timeout: 1213/1216/1219/1223/1237 all died as "Canceled" with
       # nothing to say about the firmware, and the containers they orphaned failed the
       # next runs with "container name already in use" (1210, 1211).
       #

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -25,37 +25,15 @@ variables:
     # just anonymously and against the unauthenticated rate limit. Escape as $${...} when
     # the shell genuinely needs braces, as the duration log line below does.
     git config --global url."https://$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/"
-    # Everything below runs inside single quotes, so it must contain no apostrophe at
-    # all — not even in a comment. One contraction ends the string and the step dies
-    # with "Syntax error: Unterminated quoted string" *after* the test has passed.
+    # No apostrophes below, comments included: one contraction closes this string.
     flock -w 18000 /lock/$FIRMWARE_ENV.lock bash -c '
       set -e
 
-      # Soak length by event: cron 4h, push to main 1h, ordinary PR 3m. Anything can
-      # opt up to the full soak below.
+      # Opt up to the full soak with a soak/* branch or [soak] in the message. On a
+      # pull_request that message is the PR title, not the head commit subject.
       #
-      # A push used to soak the full 4h, so a UI-only dependabot push held all four
-      # device locks for that long. With flock -w 18000 on top, pipelines stacked up
-      # past the 600m repo timeout: 1213/1216/1219/1223/1237 all died as "Canceled"
-      # with nothing to say about the firmware, and the containers they orphaned
-      # failed the next runs with "container name already in use" (1210, 1211).
-      #
-      # 1h rather than the smoke, because main is what the nightly builds on and a 3m
-      # run only catches an immediate crash. 1h plus the build is ~70m per board, so
-      # even a queue of pushes stays well inside the 600m timeout.
-      #
-      # 4h, not 8h. #2309 declines at ~22KB/h from ~160KB, so a leak of that size is
-      # unambiguous by 4h, and halving the run doubles how many soaks the single bench
-      # can serve — which is the actual constraint now that PRs can request one.
-      #
-      # Two ways to ask for the full soak, because you do not always know a change is
-      # memory-related when you name the branch:
-      #   * push it as soak/<whatever>
-      #   * put [soak] in the message CrowCI reports for the event
-      #
-      # On a pull_request that message is the PR *title*, not the head commit subject.
-      # ESPresense#2495 carried [soak] in its commit subject and still ran the 3m smoke
-      # (pipeline 1255, 6m end to end), so put it in the title to opt a PR in.
+      # Keep wait + build + soak under the 600m repo timeout, or the pipeline is
+      # cancelled with no useful log.
       SOAK_SECS=14400
       case "$CI_PIPELINE_EVENT" in
         cron) DURATION_SECS=$SOAK_SECS ;;

--- a/.woodpecker/hil.yml
+++ b/.woodpecker/hil.yml
@@ -31,32 +31,39 @@ variables:
     flock -w 18000 /lock/$FIRMWARE_ENV.lock bash -c '
       set -e
 
-      # Soak length. Only the nightly cron gets the full run by default; pushes and
-      # ordinary PRs get the smoke. A PR opts in either way below; a push only via
-      # [soak] in the message, since CI_COMMIT_SOURCE_BRANCH is a PR-only variable.
+      # Soak length by event: cron 4h, push to main 1h, ordinary PR 3m. Anything can
+      # opt up to the full soak below.
       #
-      # A push to main used to soak too, so a UI-only dependabot push held all four
-      # device locks for 4h. With flock -w 18000 on top, pipelines stacked up past the
-      # 600m repo timeout: 1213/1216/1219/1223/1237 all died as "Canceled" with
-      # nothing to say about the firmware, and the containers they orphaned failed the
-      # next runs with "container name already in use" (1210, 1211).
+      # A push used to soak the full 4h, so a UI-only dependabot push held all four
+      # device locks for that long. With flock -w 18000 on top, pipelines stacked up
+      # past the 600m repo timeout: 1213/1216/1219/1223/1237 all died as "Canceled"
+      # with nothing to say about the firmware, and the containers they orphaned
+      # failed the next runs with "container name already in use" (1210, 1211).
+      #
+      # 1h rather than the smoke, because main is what the nightly builds on and a 3m
+      # run only catches an immediate crash. 1h plus the build is ~70m per board, so
+      # even a queue of pushes stays well inside the 600m timeout.
       #
       # 4h, not 8h. #2309 declines at ~22KB/h from ~160KB, so a leak of that size is
       # unambiguous by 4h, and halving the run doubles how many soaks the single bench
       # can serve — which is the actual constraint now that PRs can request one.
       #
-      # Two ways for a PR to ask for a soak, because you do not always know a change is
+      # Two ways to ask for the full soak, because you do not always know a change is
       # memory-related when you name the branch:
       #   * push it as soak/<whatever>
-      #   * put [soak] anywhere in the head commit message (an empty commit works, and
-      #     unlike renaming a branch it does not close the PR)
+      #   * put [soak] in the message CrowCI reports for the event
+      #
+      # On a pull_request that message is the PR *title*, not the head commit subject.
+      # ESPresense#2495 carried [soak] in its commit subject and still ran the 3m smoke
+      # (pipeline 1255, 6m end to end), so put it in the title to opt a PR in.
       SOAK_SECS=14400
-      DURATION_SECS=$SOAK_SECS
-      if [ "$CI_PIPELINE_EVENT" != "cron" ]; then
-        DURATION_SECS=180
-        case "$CI_COMMIT_SOURCE_BRANCH" in soak/*) DURATION_SECS=$SOAK_SECS ;; esac
-        case "$CI_COMMIT_MESSAGE" in *"[soak]"*) DURATION_SECS=$SOAK_SECS ;; esac
-      fi
+      case "$CI_PIPELINE_EVENT" in
+        cron) DURATION_SECS=$SOAK_SECS ;;
+        push) DURATION_SECS=3600 ;;
+        *)    DURATION_SECS=180 ;;
+      esac
+      case "$CI_COMMIT_SOURCE_BRANCH" in soak/*) DURATION_SECS=$SOAK_SECS ;; esac
+      case "$CI_COMMIT_MESSAGE" in *"[soak]"*) DURATION_SECS=$SOAK_SECS ;; esac
       # $${...} escapes the brace form past Woodpecker so the shell expands it after the
       # assignments above. Braces are needed to keep the "s" out of the variable name.
       echo "HIL $FIRMWARE_ENV: $${DURATION_SECS}s (event=$CI_PIPELINE_EVENT branch=$CI_COMMIT_SOURCE_BRANCH)"


### PR DESCRIPTION
Replaces the `if` in `.woodpecker/hil.yml` with a case per event.

| event | before | after |
|---|---|---|
| cron | 4h | 4h |
| push to main | 4h | **1h** |
| pull_request | 3m | 3m |

## Why

A push soaked the full 4h on all four boards, so a UI-only dependabot push held every device lock for the duration. With `flock -w 18000` on top, pipelines stacked up past the 600m repo timeout — 1213, 1216, 1219, 1223 and 1237 all died with workflow error `Canceled` and nothing to say about the firmware:

```
Error response from daemon: Conflict. The container name
"/espresense-espresense-1210-1-test-esp32c6" is already in use
```

...and the containers those cancels orphaned failed the *next* runs outright, every step exit 126 (1210, 1211).

1h rather than dropping to the smoke: main is what the nightly builds on, and a 3m run only catches an immediate crash. 1h plus the build is ~70m per board, so even a queue of pushes stays well inside the timeout.

## Opt-ins

Moving to a `case` means `soak/*` and `[soak]` now apply to a push too, not just a PR. Verified across the matrix:

| event | plain | `[soak]` |
|---|---|---|
| cron | 14400s | 14400s |
| push | 3600s | 14400s |
| pull_request | 180s | 14400s |

`soak/*` branch on a PR → 14400s.

Also corrects the opt-in comment: **on a pull_request the message CrowCI reports is the PR title, not the head commit subject.** #2495 carried `[soak]` in its commit subject and still ran the 3m smoke (pipeline 1255, 6m end to end) — so its green is a smoke result, not the soak it was meant to get.

## Checks

`crow lint` passes; the extracted `bash -c` payload passes `bash -n` and `sh -n`, and contains zero apostrophes — the earlier revision of this PR died on `Syntax error: Unterminated quoted string` from a contraction in a comment, *after* the tests had passed. There is now a note at the quote boundary saying so.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated validation durations based on event type:
    - Scheduled runs receive 4 hours.
    - Push-triggered runs receive 1 hour.
    - Other events receive 180 seconds by default.
  - Runs for `soak/*` branches or messages containing `[soak]` now use the full soak duration.
  - Pull-request titles are used when evaluating message-based overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->